### PR TITLE
[Feat] 유저 정보 수정 및 자치구 관련 api 기능 구현

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,14 @@
+language: "ko-KR"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+chat:
+  auto_reply: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,11 @@ jobs:
           ${{ secrets.APPLICATION_PROD_YML }}
           EOF
 
+          # application-cloud.yml
+          cat > ./src/main/resources/application-cloud.yml <<'EOF'
+          ${{ secrets.APPLICATION_CLOUD_YML }}
+          EOF
+
       - name: Verify config files exist
         run: ls -l ./src/main/resources/application*.yml
 

--- a/src/main/java/com/trashheroesbe/TrashHeroesBeApplication.java
+++ b/src/main/java/com/trashheroesbe/TrashHeroesBeApplication.java
@@ -2,7 +2,9 @@ package com.trashheroesbe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class TrashHeroesBeApplication {
 

--- a/src/main/java/com/trashheroesbe/TrashHeroesBeApplication.java
+++ b/src/main/java/com/trashheroesbe/TrashHeroesBeApplication.java
@@ -2,9 +2,8 @@ package com.trashheroesbe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
+
 @SpringBootApplication
 public class TrashHeroesBeApplication {
 

--- a/src/main/java/com/trashheroesbe/feature/auth/api/FaviconController.java
+++ b/src/main/java/com/trashheroesbe/feature/auth/api/FaviconController.java
@@ -1,4 +1,4 @@
-package com.trashheroesbe.feature.auth.controller;
+package com.trashheroesbe.feature.auth.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/trashheroesbe/feature/auth/api/KakaoAuthController.java
+++ b/src/main/java/com/trashheroesbe/feature/auth/api/KakaoAuthController.java
@@ -1,9 +1,8 @@
-package com.trashheroesbe.feature.auth.controller;
+package com.trashheroesbe.feature.auth.api;
 
 import static com.trashheroesbe.global.response.type.SuccessCode.OK;
 
-import com.trashheroesbe.feature.auth.api.AuthControllerApi;
-import com.trashheroesbe.feature.auth.service.KakaoAuthService;
+import com.trashheroesbe.feature.auth.application.KakaoAuthService;
 import com.trashheroesbe.global.response.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;

--- a/src/main/java/com/trashheroesbe/feature/auth/application/KakaoAuthService.java
+++ b/src/main/java/com/trashheroesbe/feature/auth/application/KakaoAuthService.java
@@ -1,9 +1,8 @@
-package com.trashheroesbe.feature.auth.service;
+package com.trashheroesbe.feature.auth.application;
 
 import static com.trashheroesbe.global.auth.jwt.entity.TokenType.ACCESS_TOKEN;
 import static com.trashheroesbe.global.auth.jwt.entity.TokenType.REFRESH_TOKEN;
 
-import com.trashheroesbe.global.auth.jwt.entity.TokenType;
 import com.trashheroesbe.global.auth.jwt.service.CookieProvider;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/trashheroesbe/feature/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/trashheroesbe/feature/auth/controller/KakaoAuthController.java
@@ -1,17 +1,14 @@
 package com.trashheroesbe.feature.auth.controller;
 
+import static com.trashheroesbe.global.response.type.SuccessCode.OK;
+
 import com.trashheroesbe.feature.auth.api.AuthControllerApi;
 import com.trashheroesbe.feature.auth.service.KakaoAuthService;
 import com.trashheroesbe.global.response.ApiResponse;
-import com.trashheroesbe.global.response.type.SuccessCode;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,12 +25,12 @@ public class KakaoAuthController implements AuthControllerApi {
     @GetMapping("/login")
     public ApiResponse<Void> login(HttpServletResponse response) throws IOException {
         response.sendRedirect("/oauth2/authorization/kakao");
-        return ApiResponse.success(SuccessCode.OK);
+        return ApiResponse.success(OK);
     }
 
     @Override
     public ApiResponse<Void> logout(HttpServletResponse response) {
         kakaoAuthService.logout(response);
-        return ApiResponse.success(SuccessCode.OK);
+        return ApiResponse.success(OK);
     }
 }

--- a/src/main/java/com/trashheroesbe/feature/district/api/DistrictController.java
+++ b/src/main/java/com/trashheroesbe/feature/district/api/DistrictController.java
@@ -1,0 +1,32 @@
+package com.trashheroesbe.feature.district.api;
+
+import static com.trashheroesbe.global.response.type.SuccessCode.OK;
+
+import com.trashheroesbe.feature.district.application.DistrictService;
+import com.trashheroesbe.feature.district.dto.response.DistrictListResponse;
+import com.trashheroesbe.global.response.ApiResponse;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/districts")
+public class DistrictController implements DistrictControllerApi {
+
+    private final DistrictService districtService;
+
+    @Override
+    @GetMapping
+    public ApiResponse<List<DistrictListResponse>> getDistrictList(
+        @RequestParam String sido,
+        @RequestParam(required = false) String sigungu
+    ) {
+        List<DistrictListResponse> response = districtService.getDistrictList(sido, sigungu);
+        return ApiResponse.success(OK, response);
+    }
+}

--- a/src/main/java/com/trashheroesbe/feature/district/api/DistrictControllerApi.java
+++ b/src/main/java/com/trashheroesbe/feature/district/api/DistrictControllerApi.java
@@ -1,0 +1,21 @@
+package com.trashheroesbe.feature.district.api;
+
+import com.trashheroesbe.feature.district.dto.response.DistrictListResponse;
+import com.trashheroesbe.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+
+@Tag(name = "District", description = "자치구 관련 API")
+public interface DistrictControllerApi {
+
+    @Operation(summary = "자치구 정보 조회하기", description = "시도, 시군구를 통해 자치구 정보를 조회한다.")
+    ApiResponse<List<DistrictListResponse>> getDistrictList(
+        @Parameter(description = "검색할 시도", example = "서울특별시")
+        String sido,
+
+        @Parameter(description = "검색할 시군구", example = "마포구")
+        String sigungu
+    );
+}

--- a/src/main/java/com/trashheroesbe/feature/district/api/DistrictControllerApi.java
+++ b/src/main/java/com/trashheroesbe/feature/district/api/DistrictControllerApi.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Tag(name = "District", description = "자치구 관련 API")
 public interface DistrictControllerApi {
 
-    @Operation(summary = "자치구 정보 조회하기", description = "시도, 시군구를 통해 자치구 정보를 조회한다.")
+    @Operation(summary = "자치구 정보 검색하기", description = "시도, 시군구를 통해 자치구 정보를 검색한다.")
     ApiResponse<List<DistrictListResponse>> getDistrictList(
         @Parameter(description = "검색할 시도", example = "서울특별시")
         String sido,

--- a/src/main/java/com/trashheroesbe/feature/district/application/DistrictService.java
+++ b/src/main/java/com/trashheroesbe/feature/district/application/DistrictService.java
@@ -1,6 +1,6 @@
 package com.trashheroesbe.feature.district.application;
 
-import com.trashheroesbe.feature.district.domain.District;
+import com.trashheroesbe.feature.district.domain.entity.District;
 import com.trashheroesbe.feature.district.dto.response.DistrictListResponse;
 import com.trashheroesbe.feature.district.infrastructure.DistrictRepository;
 import java.util.List;

--- a/src/main/java/com/trashheroesbe/feature/district/application/DistrictService.java
+++ b/src/main/java/com/trashheroesbe/feature/district/application/DistrictService.java
@@ -1,0 +1,32 @@
+package com.trashheroesbe.feature.district.application;
+
+import com.trashheroesbe.feature.district.domain.District;
+import com.trashheroesbe.feature.district.dto.response.DistrictListResponse;
+import com.trashheroesbe.feature.district.infrastructure.DistrictRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DistrictService {
+
+    private final DistrictRepository districtRepository;
+
+    public List<DistrictListResponse> getDistrictList(String sido, String sigungu) {
+
+        List<District> districtList;
+        if (sigungu == null) {
+            districtList = districtRepository.findDistrictsBySido(sido);
+        } else {
+            districtList = districtRepository.findEupmyeondongBySidoAndSigungu(sido, sigungu);
+        }
+
+        return districtList.stream()
+            .map(DistrictListResponse::from)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/trashheroesbe/feature/district/domain/District.java
+++ b/src/main/java/com/trashheroesbe/feature/district/domain/District.java
@@ -1,0 +1,36 @@
+package com.trashheroesbe.feature.district.domain;
+
+import com.trashheroesbe.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "districts")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class District extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String code;
+
+    @Column(nullable = false)
+    private String sido;
+
+    @Column
+    private String sigungu;
+
+    @Column
+    private String eupmyeondong;
+
+}

--- a/src/main/java/com/trashheroesbe/feature/district/domain/District.java
+++ b/src/main/java/com/trashheroesbe/feature/district/domain/District.java
@@ -3,8 +3,6 @@ package com.trashheroesbe.feature.district.domain;
 import com.trashheroesbe.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -15,14 +13,11 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "districts")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class District extends BaseTimeEntity {
+public class District {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @Column(nullable = false)
-    private String code;
+    @Column(length = 12)
+    private String id;
 
     @Column(nullable = false)
     private String sido;

--- a/src/main/java/com/trashheroesbe/feature/district/domain/entity/District.java
+++ b/src/main/java/com/trashheroesbe/feature/district/domain/entity/District.java
@@ -1,6 +1,5 @@
-package com.trashheroesbe.feature.district.domain;
+package com.trashheroesbe.feature.district.domain.entity;
 
-import com.trashheroesbe.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;

--- a/src/main/java/com/trashheroesbe/feature/district/domain/service/DistrictFinder.java
+++ b/src/main/java/com/trashheroesbe/feature/district/domain/service/DistrictFinder.java
@@ -1,0 +1,24 @@
+package com.trashheroesbe.feature.district.domain.service;
+
+import static com.trashheroesbe.global.response.type.ErrorCode.ENTITY_NOT_FOUND;
+
+import com.trashheroesbe.feature.district.domain.entity.District;
+import com.trashheroesbe.feature.district.infrastructure.DistrictRepository;
+import com.trashheroesbe.global.exception.BusinessException;
+import com.trashheroesbe.global.response.type.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DistrictFinder {
+
+    private final DistrictRepository districtRepository;
+
+    public District findById(String distributeId) {
+        return districtRepository.findById(distributeId)
+            .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/trashheroesbe/feature/district/dto/response/DistrictListResponse.java
+++ b/src/main/java/com/trashheroesbe/feature/district/dto/response/DistrictListResponse.java
@@ -1,6 +1,6 @@
 package com.trashheroesbe.feature.district.dto.response;
 
-import com.trashheroesbe.feature.district.domain.District;
+import com.trashheroesbe.feature.district.domain.entity.District;
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/trashheroesbe/feature/district/dto/response/DistrictListResponse.java
+++ b/src/main/java/com/trashheroesbe/feature/district/dto/response/DistrictListResponse.java
@@ -1,0 +1,22 @@
+package com.trashheroesbe.feature.district.dto.response;
+
+import com.trashheroesbe.feature.district.domain.District;
+import lombok.Builder;
+
+@Builder
+public record DistrictListResponse(
+    String districtId,
+    String sido,
+    String sigugn,
+    String eupmyeondong
+) {
+
+    public static DistrictListResponse from(District district) {
+        return DistrictListResponse.builder()
+            .districtId(district.getId())
+            .sido(district.getSido())
+            .sigugn(district.getSigungu())
+            .eupmyeondong(district.getEupmyeondong())
+            .build();
+    }
+}

--- a/src/main/java/com/trashheroesbe/feature/district/infrastructure/DistrictRepository.java
+++ b/src/main/java/com/trashheroesbe/feature/district/infrastructure/DistrictRepository.java
@@ -1,6 +1,6 @@
 package com.trashheroesbe.feature.district.infrastructure;
 
-import com.trashheroesbe.feature.district.domain.District;
+import com.trashheroesbe.feature.district.domain.entity.District;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface DistrictRepository extends JpaRepository<District, Long> {
+public interface DistrictRepository extends JpaRepository<District, String> {
 
     @Query("""
         SELECT d

--- a/src/main/java/com/trashheroesbe/feature/district/infrastructure/DistrictRepository.java
+++ b/src/main/java/com/trashheroesbe/feature/district/infrastructure/DistrictRepository.java
@@ -1,0 +1,35 @@
+package com.trashheroesbe.feature.district.infrastructure;
+
+import com.trashheroesbe.feature.district.domain.District;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DistrictRepository extends JpaRepository<District, Long> {
+
+    @Query("""
+        SELECT d
+        FROM District d
+        WHERE d.sido LIKE CONCAT('%', :sido, '%')
+          AND d.sigungu IS NOT NULL
+          AND d.eupmyeondong IS NULL
+        ORDER BY d.sigungu ASC
+        """)
+    List<District> findDistrictsBySido(@Param("sido") String sido);
+
+    @Query("""
+        SELECT d
+        FROM District d
+        WHERE d.sido LIKE CONCAT('%', :sido, '%')
+          AND d.sigungu LIKE CONCAT('%', :sigungu, '%')
+          AND d.eupmyeondong IS NOT NULL
+        ORDER BY d.eupmyeondong ASC
+        """)
+    List<District> findEupmyeondongBySidoAndSigungu(
+        @Param("sido") String sido,
+        @Param("sigungu") String sigungu
+    );
+}

--- a/src/main/java/com/trashheroesbe/feature/trash/api/TrashController.java
+++ b/src/main/java/com/trashheroesbe/feature/trash/api/TrashController.java
@@ -1,7 +1,7 @@
 package com.trashheroesbe.feature.trash.api;
 
 import com.trashheroesbe.feature.trash.application.TrashService;
-import com.trashheroesbe.feature.trash.dto.request.TrashCreateRequest;
+import com.trashheroesbe.feature.trash.dto.request.CreateTrashRequest;
 import com.trashheroesbe.feature.trash.dto.response.TrashResult;
 import com.trashheroesbe.feature.trash.application.TrashCreateUseCase;
 import com.trashheroesbe.global.auth.security.CustomerDetails;
@@ -26,7 +26,7 @@ public class TrashController implements TrashControllerApi {
     @Override
     @PostMapping
     public ApiResponse<TrashResult> createTrash(
-            @ModelAttribute TrashCreateRequest request,
+            @ModelAttribute CreateTrashRequest request,
             @AuthenticationPrincipal CustomerDetails customerDetails
     ) {
         log.info("쓰레기 생성 요청: userId={}, fileName={}",

--- a/src/main/java/com/trashheroesbe/feature/trash/api/TrashControllerApi.java
+++ b/src/main/java/com/trashheroesbe/feature/trash/api/TrashControllerApi.java
@@ -1,7 +1,7 @@
 package com.trashheroesbe.feature.trash.api;
 
 
-import com.trashheroesbe.feature.trash.dto.request.TrashCreateRequest;
+import com.trashheroesbe.feature.trash.dto.request.CreateTrashRequest;
 import com.trashheroesbe.feature.trash.dto.response.TrashResult;
 import com.trashheroesbe.global.auth.security.CustomerDetails;
 import com.trashheroesbe.global.response.ApiResponse;
@@ -23,11 +23,11 @@ public interface TrashControllerApi {
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     content = @Content(
                             mediaType = "multipart/form-data",
-                            schema = @Schema(implementation = TrashCreateRequest.class)
+                            schema = @Schema(implementation = CreateTrashRequest.class)
                     )
             )
     )
-    ApiResponse<TrashResult> createTrash(TrashCreateRequest request, @AuthenticationPrincipal CustomerDetails customerDetails);
+    ApiResponse<TrashResult> createTrash(CreateTrashRequest request, @AuthenticationPrincipal CustomerDetails customerDetails);
 
     @Operation(summary = "쓰레기 조회", description = "쓰레기 ID로 정보를 조회합니다.")
     ApiResponse<TrashResult> getTrash(@PathVariable Long trashId);

--- a/src/main/java/com/trashheroesbe/feature/trash/application/TrashCreateUseCase.java
+++ b/src/main/java/com/trashheroesbe/feature/trash/application/TrashCreateUseCase.java
@@ -1,10 +1,10 @@
 package com.trashheroesbe.feature.trash.application;
 
-import com.trashheroesbe.feature.trash.dto.request.TrashCreateRequest;
+import com.trashheroesbe.feature.trash.dto.request.CreateTrashRequest;
 import com.trashheroesbe.feature.trash.dto.response.TrashResult;
-import com.trashheroesbe.feature.user.domain.User;
+import com.trashheroesbe.feature.user.domain.entity.User;
 
 public interface TrashCreateUseCase {
 
-    TrashResult createTrash(TrashCreateRequest request, User user);
+    TrashResult createTrash(CreateTrashRequest request, User user);
 }

--- a/src/main/java/com/trashheroesbe/feature/trash/application/TrashService.java
+++ b/src/main/java/com/trashheroesbe/feature/trash/application/TrashService.java
@@ -27,6 +27,8 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class TrashService implements TrashCreateUseCase {
 
+    private static final String S3_TRASH_PREFIX = "trash/";
+
     private final TrashRepository trashRepository;
     private final FileStoragePort fileStoragePort;
 
@@ -42,6 +44,7 @@ public class TrashService implements TrashCreateUseCase {
                 Objects.requireNonNull(request.imageFile().getOriginalFilename()));
             String imageUrl = fileStoragePort.uploadFile(
                 storedFileName,
+                S3_TRASH_PREFIX,
                 request.imageFile().getContentType(),
                 request.imageFile().getBytes()
             );

--- a/src/main/java/com/trashheroesbe/feature/trash/application/TrashService.java
+++ b/src/main/java/com/trashheroesbe/feature/trash/application/TrashService.java
@@ -1,13 +1,13 @@
 package com.trashheroesbe.feature.trash.application;
 
-import com.trashheroesbe.feature.trash.dto.request.TrashCreateRequest;
+import com.trashheroesbe.feature.trash.dto.request.CreateTrashRequest;
 import com.trashheroesbe.feature.trash.dto.response.TrashResult;
 import com.trashheroesbe.feature.trash.domain.Trash;
 import com.trashheroesbe.feature.trash.infrastructure.TrashRepository;
-import com.trashheroesbe.feature.user.domain.User;
+import com.trashheroesbe.feature.user.domain.entity.User;
 import com.trashheroesbe.global.exception.BusinessException;
 import com.trashheroesbe.global.response.type.ErrorCode;
-import com.trashheroesbe.global.s3.application.FileStorageService;
+import com.trashheroesbe.infrastructure.port.s3.FileStoragePort;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,11 +27,11 @@ import java.util.stream.Collectors;
 public class TrashService implements TrashCreateUseCase {
 
     private final TrashRepository trashRepository;
-    private final FileStorageService fileStorageService;
+    private final FileStoragePort fileStoragePort;
 
     @Override
     @Transactional
-    public TrashResult createTrash(TrashCreateRequest request, User user) {
+    public TrashResult createTrash(CreateTrashRequest request, User user) {
         log.info("쓰레기 생성 시작: userId={}", user.getId());
 
         request.validate();
@@ -39,7 +39,7 @@ public class TrashService implements TrashCreateUseCase {
         try {
             String storedFileName = generateStoredFileName(
                     Objects.requireNonNull(request.imageFile().getOriginalFilename()));
-            String imageUrl = fileStorageService.uploadFile(
+            String imageUrl = fileStoragePort.uploadFile(
                     storedFileName,
                     request.imageFile().getContentType(),
                     request.imageFile().getBytes()

--- a/src/main/java/com/trashheroesbe/feature/trash/domain/Trash.java
+++ b/src/main/java/com/trashheroesbe/feature/trash/domain/Trash.java
@@ -1,6 +1,7 @@
 package com.trashheroesbe.feature.trash.domain;
 
-import com.trashheroesbe.feature.user.domain.User;
+
+import com.trashheroesbe.feature.user.domain.entity.User;
 import com.trashheroesbe.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/trashheroesbe/feature/trash/dto/request/CreateTrashRequest.java
+++ b/src/main/java/com/trashheroesbe/feature/trash/dto/request/CreateTrashRequest.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import org.springframework.web.multipart.MultipartFile;
 
 @Builder
-public record TrashCreateRequest(
+public record CreateTrashRequest(
         MultipartFile imageFile
 ) {
     public void validate() {

--- a/src/main/java/com/trashheroesbe/feature/trash/infrastructure/TrashRepository.java
+++ b/src/main/java/com/trashheroesbe/feature/trash/infrastructure/TrashRepository.java
@@ -1,7 +1,7 @@
 package com.trashheroesbe.feature.trash.infrastructure;
 
 import com.trashheroesbe.feature.trash.domain.Trash;
-import com.trashheroesbe.feature.user.domain.User;
+import com.trashheroesbe.feature.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/trashheroesbe/feature/user/api/UserController.java
+++ b/src/main/java/com/trashheroesbe/feature/user/api/UserController.java
@@ -7,13 +7,15 @@ import com.trashheroesbe.feature.user.dto.request.UpdateUserRequest;
 import com.trashheroesbe.global.response.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
-@RestControllerAdvice
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
 public class UserController implements UserControllerApi {
@@ -21,12 +23,13 @@ public class UserController implements UserControllerApi {
     private final UserService userService;
 
     @Override
-    @PatchMapping("/{userId}")
+    @PatchMapping(value = "/{userId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<Long> updateUser(
-        @RequestBody UpdateUserRequest request,
+        @RequestPart("metadata") UpdateUserRequest request,
+        @RequestPart(value = "image", required = false) MultipartFile image,
         @PathVariable Long userId
     ) {
-        userService.updateUser(request, userId);
+        userService.updateUser(request, image, userId);
         return ApiResponse.success(OK, userId);
     }
 }

--- a/src/main/java/com/trashheroesbe/feature/user/api/UserController.java
+++ b/src/main/java/com/trashheroesbe/feature/user/api/UserController.java
@@ -4,10 +4,13 @@ import static com.trashheroesbe.global.response.type.SuccessCode.OK;
 
 import com.trashheroesbe.feature.user.application.UserService;
 import com.trashheroesbe.feature.user.dto.request.UpdateUserRequest;
+import com.trashheroesbe.global.auth.security.CustomerDetails;
 import com.trashheroesbe.global.response.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,23 +28,33 @@ public class UserController implements UserControllerApi {
     private final UserService userService;
 
     @Override
-    @PatchMapping(value = "/{userId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<Long> updateUser(
         @RequestPart("metadata") UpdateUserRequest request,
         @RequestPart(value = "image", required = false) MultipartFile image,
-        @PathVariable Long userId
+        @AuthenticationPrincipal CustomerDetails customerDetails
     ) {
+        Long userId = customerDetails.getUser().getId();
         userService.updateUser(request, image, userId);
         return ApiResponse.success(OK, userId);
     }
 
     @Override
-    @PostMapping("/{userId}/districts/{districtId}")
+    @PostMapping("/districts/{districtId}")
     public ApiResponse<Void> createUserDistrict(
-        @PathVariable Long userId,
+        @AuthenticationPrincipal CustomerDetails customerDetails,
         @PathVariable String districtId
     ) {
-        userService.createUserDistrict(userId, districtId);
+        userService.createUserDistrict(customerDetails.getUser().getId(), districtId);
+        return ApiResponse.success(OK);
+    }
+
+    @Override
+    @DeleteMapping("/districts/{userDistrictId}")
+    public ApiResponse<Void> deleteUserDistrict(
+        @PathVariable Long userDistrictId
+    ) {
+        userService.deleteUserDistrict(userDistrictId);
         return ApiResponse.success(OK);
     }
 }

--- a/src/main/java/com/trashheroesbe/feature/user/api/UserController.java
+++ b/src/main/java/com/trashheroesbe/feature/user/api/UserController.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,5 +33,15 @@ public class UserController implements UserControllerApi {
     ) {
         userService.updateUser(request, image, userId);
         return ApiResponse.success(OK, userId);
+    }
+
+    @Override
+    @PostMapping("/{userId}/districts/{districtId}")
+    public ApiResponse<Void> createUserDistrict(
+        @PathVariable Long userId,
+        @PathVariable String districtId
+    ) {
+        userService.createUserDistrict(userId, districtId);
+        return ApiResponse.success(OK);
     }
 }

--- a/src/main/java/com/trashheroesbe/feature/user/api/UserController.java
+++ b/src/main/java/com/trashheroesbe/feature/user/api/UserController.java
@@ -2,15 +2,18 @@ package com.trashheroesbe.feature.user.api;
 
 import static com.trashheroesbe.global.response.type.SuccessCode.OK;
 
+import com.trashheroesbe.feature.district.dto.response.DistrictListResponse;
 import com.trashheroesbe.feature.user.application.UserService;
 import com.trashheroesbe.feature.user.dto.request.UpdateUserRequest;
 import com.trashheroesbe.global.auth.security.CustomerDetails;
 import com.trashheroesbe.global.response.ApiResponse;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -56,5 +59,15 @@ public class UserController implements UserControllerApi {
     ) {
         userService.deleteUserDistrict(userDistrictId);
         return ApiResponse.success(OK);
+    }
+
+    @Override
+    @GetMapping("/me/districts")
+    public ApiResponse<List<DistrictListResponse>> getMyDistricts(
+        @AuthenticationPrincipal CustomerDetails customerDetails
+    ) {
+        List<DistrictListResponse> response = userService.getUserDistrictsByUserId(
+            customerDetails.getUser().getId());
+        return ApiResponse.success(OK, response);
     }
 }

--- a/src/main/java/com/trashheroesbe/feature/user/api/UserController.java
+++ b/src/main/java/com/trashheroesbe/feature/user/api/UserController.java
@@ -1,8 +1,7 @@
-package com.trashheroesbe.feature.user.controller;
+package com.trashheroesbe.feature.user.api;
 
 import static com.trashheroesbe.global.response.type.SuccessCode.OK;
 
-import com.trashheroesbe.feature.user.api.UserControllerApi;
 import com.trashheroesbe.feature.user.application.UserService;
 import com.trashheroesbe.feature.user.dto.request.UpdateUserRequest;
 import com.trashheroesbe.global.response.ApiResponse;

--- a/src/main/java/com/trashheroesbe/feature/user/api/UserControllerApi.java
+++ b/src/main/java/com/trashheroesbe/feature/user/api/UserControllerApi.java
@@ -11,7 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "User", description = "유저 관련 API")
 public interface UserControllerApi {
 
-    @Operation(summary = "유저 수정하기(patch)", description = "유저의 정보를 수정합니다.(nickname, profileImg, district")
+    @Operation(summary = "유저 수정하기(patch)", description = "유저의 정보를 수정합니다.(nickname, profileImg")
     ApiResponse<Long> updateUser(
         @Parameter(description = "수정할 사용자 정보 JSON")
         UpdateUserRequest request,

--- a/src/main/java/com/trashheroesbe/feature/user/api/UserControllerApi.java
+++ b/src/main/java/com/trashheroesbe/feature/user/api/UserControllerApi.java
@@ -3,12 +3,22 @@ package com.trashheroesbe.feature.user.api;
 import com.trashheroesbe.feature.user.dto.request.UpdateUserRequest;
 import com.trashheroesbe.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.multipart.MultipartFile;
 
 
 @Tag(name = "User", description = "유저 관련 API")
 public interface UserControllerApi {
 
     @Operation(summary = "유저 수정하기(patch)", description = "유저의 정보를 수정합니다.(nickname, profileImg, district")
-    ApiResponse<Long> updateUser(UpdateUserRequest request, Long userId);
+    ApiResponse<Long> updateUser(
+        @Parameter(description = "수정할 사용자 정보 JSON")
+        UpdateUserRequest request,
+
+        @Parameter(description = "업로드할 이미지 파일")
+        MultipartFile image,
+
+        Long userId
+    );
 }

--- a/src/main/java/com/trashheroesbe/feature/user/api/UserControllerApi.java
+++ b/src/main/java/com/trashheroesbe/feature/user/api/UserControllerApi.java
@@ -21,4 +21,7 @@ public interface UserControllerApi {
 
         Long userId
     );
+
+    @Operation(summary = "유저 자치구 추가하기", description = "유저의 자치구를 추가합니다.")
+    ApiResponse<Void> createUserDistrict(Long userId, String districtId);
 }

--- a/src/main/java/com/trashheroesbe/feature/user/api/UserControllerApi.java
+++ b/src/main/java/com/trashheroesbe/feature/user/api/UserControllerApi.java
@@ -1,11 +1,13 @@
 package com.trashheroesbe.feature.user.api;
 
+import com.trashheroesbe.feature.district.dto.response.DistrictListResponse;
 import com.trashheroesbe.feature.user.dto.request.UpdateUserRequest;
 import com.trashheroesbe.global.auth.security.CustomerDetails;
 import com.trashheroesbe.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 
@@ -28,4 +30,7 @@ public interface UserControllerApi {
 
     @Operation(summary = "유저 자치구 삭제하기", description = "유저의 자치구를 삭제합니다.")
     ApiResponse<Void> deleteUserDistrict(Long userDistrictId);
+
+    @Operation(summary = "내 자치구 조회하기", description = "나의 등록된 자치구를 조회합니다.")
+    ApiResponse<List<DistrictListResponse>> getMyDistricts(CustomerDetails customerDetails);
 }

--- a/src/main/java/com/trashheroesbe/feature/user/api/UserControllerApi.java
+++ b/src/main/java/com/trashheroesbe/feature/user/api/UserControllerApi.java
@@ -1,6 +1,7 @@
 package com.trashheroesbe.feature.user.api;
 
 import com.trashheroesbe.feature.user.dto.request.UpdateUserRequest;
+import com.trashheroesbe.global.auth.security.CustomerDetails;
 import com.trashheroesbe.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,9 +20,12 @@ public interface UserControllerApi {
         @Parameter(description = "업로드할 이미지 파일")
         MultipartFile image,
 
-        Long userId
+        CustomerDetails customerDetails
     );
 
     @Operation(summary = "유저 자치구 추가하기", description = "유저의 자치구를 추가합니다.")
-    ApiResponse<Void> createUserDistrict(Long userId, String districtId);
+    ApiResponse<Void> createUserDistrict(CustomerDetails customerDetails, String districtId);
+
+    @Operation(summary = "유저 자치구 삭제하기", description = "유저의 자치구를 삭제합니다.")
+    ApiResponse<Void> deleteUserDistrict(Long userDistrictId);
 }

--- a/src/main/java/com/trashheroesbe/feature/user/api/UserControllerApi.java
+++ b/src/main/java/com/trashheroesbe/feature/user/api/UserControllerApi.java
@@ -1,0 +1,14 @@
+package com.trashheroesbe.feature.user.api;
+
+import com.trashheroesbe.feature.user.dto.request.UpdateUserRequest;
+import com.trashheroesbe.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+
+@Tag(name = "User", description = "유저 관련 API")
+public interface UserControllerApi {
+
+    @Operation(summary = "유저 수정하기(patch)", description = "유저의 정보를 수정합니다.(nickname, profileImg, district")
+    ApiResponse<Long> updateUser(UpdateUserRequest request, Long userId);
+}

--- a/src/main/java/com/trashheroesbe/feature/user/application/UserService.java
+++ b/src/main/java/com/trashheroesbe/feature/user/application/UserService.java
@@ -1,12 +1,16 @@
 package com.trashheroesbe.feature.user.application;
 
+import static com.trashheroesbe.global.response.type.ErrorCode.DUPLICATE_USER_DISTRICT;
 import static com.trashheroesbe.global.response.type.ErrorCode.S3_UPLOAD_FAIL;
 
 import com.trashheroesbe.feature.district.domain.entity.District;
 import com.trashheroesbe.feature.district.domain.service.DistrictFinder;
 import com.trashheroesbe.feature.user.domain.entity.User;
+import com.trashheroesbe.feature.user.domain.entity.UserDistrict;
+import com.trashheroesbe.feature.user.domain.service.UserDistrictFinder;
 import com.trashheroesbe.feature.user.domain.service.UserFinder;
 import com.trashheroesbe.feature.user.dto.request.UpdateUserRequest;
+import com.trashheroesbe.feature.user.infrastructure.UserDistrictRepository;
 import com.trashheroesbe.feature.user.infrastructure.UserRepository;
 import com.trashheroesbe.global.exception.BusinessException;
 import com.trashheroesbe.global.util.FileUtils;
@@ -24,11 +28,14 @@ public class UserService {
 
     private static final String S3_USER_PREFIX = "user/";
 
-    private final DistrictFinder districtFinder;
     private final FileStoragePort fileStoragePort;
 
+    private final DistrictFinder districtFinder;
     private final UserFinder userFinder;
+    private final UserDistrictFinder userDistrictFinder;
+    private final UserDistrictRepository userDistrictRepository;
     private final UserRepository userRepository;
+
 
     @Transactional
     public void updateUser(UpdateUserRequest request, MultipartFile image, Long userId) {
@@ -55,5 +62,19 @@ public class UserService {
             }
             user.updateProfileImageUrl(imageUrl);
         }
+    }
+
+    @Transactional
+    public void createUserDistrict(Long userId, String districtId) {
+
+        if (userDistrictFinder.existsByUserIdAndDistrictId(userId, districtId)) {
+            throw new BusinessException(DUPLICATE_USER_DISTRICT);
+        }
+
+        User user = userFinder.findById(userId);
+        District district = districtFinder.findById(districtId);
+
+        UserDistrict userDistrict = UserDistrict.createUserDistrict(user, district);
+        userDistrictRepository.save(userDistrict);
     }
 }

--- a/src/main/java/com/trashheroesbe/feature/user/application/UserService.java
+++ b/src/main/java/com/trashheroesbe/feature/user/application/UserService.java
@@ -1,6 +1,8 @@
 package com.trashheroesbe.feature.user.application;
 
 import static com.trashheroesbe.global.response.type.ErrorCode.DUPLICATE_USER_DISTRICT;
+import static com.trashheroesbe.global.response.type.ErrorCode.ENTITY_NOT_FOUND;
+import static com.trashheroesbe.global.response.type.ErrorCode.MAX_USER_DISTRICTS_EXCEEDED;
 import static com.trashheroesbe.global.response.type.ErrorCode.S3_UPLOAD_FAIL;
 
 import com.trashheroesbe.feature.district.domain.entity.District;
@@ -15,6 +17,7 @@ import com.trashheroesbe.feature.user.infrastructure.UserRepository;
 import com.trashheroesbe.global.exception.BusinessException;
 import com.trashheroesbe.global.util.FileUtils;
 import com.trashheroesbe.infrastructure.port.s3.FileStoragePort;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,6 +30,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserService {
 
     private static final String S3_USER_PREFIX = "user/";
+    private static final int MAX_USER_DISTRICTS = 2;
 
     private final FileStoragePort fileStoragePort;
 
@@ -66,8 +70,16 @@ public class UserService {
 
     @Transactional
     public void createUserDistrict(Long userId, String districtId) {
+        List<UserDistrict> userDistricts = userDistrictFinder.findByUserId(userId);
 
-        if (userDistrictFinder.existsByUserIdAndDistrictId(userId, districtId)) {
+        if (userDistricts.size() >= MAX_USER_DISTRICTS) {
+            throw new BusinessException(MAX_USER_DISTRICTS_EXCEEDED);
+        }
+
+        boolean alreadyExists = userDistricts.stream()
+            .anyMatch(ud -> ud.getDistrict().getId().equals(districtId));
+
+        if (alreadyExists) {
             throw new BusinessException(DUPLICATE_USER_DISTRICT);
         }
 
@@ -76,5 +88,13 @@ public class UserService {
 
         UserDistrict userDistrict = UserDistrict.createUserDistrict(user, district);
         userDistrictRepository.save(userDistrict);
+    }
+
+    @Transactional
+    public void deleteUserDistrict(Long userDistrictId) {
+        if (!userDistrictFinder.existsByUserDistrictId(userDistrictId)) {
+            throw new BusinessException(ENTITY_NOT_FOUND);
+        }
+        userDistrictRepository.deleteById(userDistrictId);
     }
 }

--- a/src/main/java/com/trashheroesbe/feature/user/application/UserService.java
+++ b/src/main/java/com/trashheroesbe/feature/user/application/UserService.java
@@ -1,30 +1,51 @@
 package com.trashheroesbe.feature.user.application;
 
+import static com.trashheroesbe.global.response.type.ErrorCode.S3_UPLOAD_FAIL;
+
 import com.trashheroesbe.feature.user.domain.entity.User;
 import com.trashheroesbe.feature.user.domain.service.UserFinder;
 import com.trashheroesbe.feature.user.dto.request.UpdateUserRequest;
 import com.trashheroesbe.feature.user.infrastructure.UserRepository;
+import com.trashheroesbe.global.exception.BusinessException;
+import com.trashheroesbe.global.util.FileUtils;
+import com.trashheroesbe.infrastructure.port.s3.FileStoragePort;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserService {
 
+    private final FileStoragePort fileStoragePort;
+
     private final UserFinder userFinder;
     private final UserRepository userRepository;
 
     @Transactional
-    public void updateUser(UpdateUserRequest request, Long userId) {
+    public void updateUser(UpdateUserRequest request, MultipartFile image, Long userId) {
         User user = userFinder.findById(userId);
 
         if (request.nickname() != null) {
             user.updateNickname(request.nickname());
         }
 
+        if (image != null && !image.isEmpty()) {
+            String imageUrl;
+            String fileName = FileUtils.generateStoredFileName(
+                Objects.requireNonNull(image.getOriginalFilename()));
 
+            try {
+                imageUrl = fileStoragePort.uploadFile(
+                    fileName, image.getContentType(), image.getBytes());
+            } catch (Exception e) {
+                throw new BusinessException(S3_UPLOAD_FAIL);
+            }
+            user.updateProfileImageUrl(imageUrl);
+        }
 
     }
 }

--- a/src/main/java/com/trashheroesbe/feature/user/application/UserService.java
+++ b/src/main/java/com/trashheroesbe/feature/user/application/UserService.java
@@ -53,5 +53,7 @@ public class UserService {
             user.updateProfileImageUrl(imageUrl);
         }
 
+
+
     }
 }

--- a/src/main/java/com/trashheroesbe/feature/user/application/UserService.java
+++ b/src/main/java/com/trashheroesbe/feature/user/application/UserService.java
@@ -2,6 +2,8 @@ package com.trashheroesbe.feature.user.application;
 
 import static com.trashheroesbe.global.response.type.ErrorCode.S3_UPLOAD_FAIL;
 
+import com.trashheroesbe.feature.district.domain.entity.District;
+import com.trashheroesbe.feature.district.domain.service.DistrictFinder;
 import com.trashheroesbe.feature.user.domain.entity.User;
 import com.trashheroesbe.feature.user.domain.service.UserFinder;
 import com.trashheroesbe.feature.user.dto.request.UpdateUserRequest;
@@ -22,6 +24,7 @@ public class UserService {
 
     private static final String S3_USER_PREFIX = "user/";
 
+    private final DistrictFinder districtFinder;
     private final FileStoragePort fileStoragePort;
 
     private final UserFinder userFinder;
@@ -52,8 +55,5 @@ public class UserService {
             }
             user.updateProfileImageUrl(imageUrl);
         }
-
-
-
     }
 }

--- a/src/main/java/com/trashheroesbe/feature/user/application/UserService.java
+++ b/src/main/java/com/trashheroesbe/feature/user/application/UserService.java
@@ -7,6 +7,7 @@ import static com.trashheroesbe.global.response.type.ErrorCode.S3_UPLOAD_FAIL;
 
 import com.trashheroesbe.feature.district.domain.entity.District;
 import com.trashheroesbe.feature.district.domain.service.DistrictFinder;
+import com.trashheroesbe.feature.district.dto.response.DistrictListResponse;
 import com.trashheroesbe.feature.user.domain.entity.User;
 import com.trashheroesbe.feature.user.domain.entity.UserDistrict;
 import com.trashheroesbe.feature.user.domain.service.UserDistrictFinder;
@@ -19,6 +20,7 @@ import com.trashheroesbe.global.util.FileUtils;
 import com.trashheroesbe.infrastructure.port.s3.FileStoragePort;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -96,5 +98,15 @@ public class UserService {
             throw new BusinessException(ENTITY_NOT_FOUND);
         }
         userDistrictRepository.deleteById(userDistrictId);
+    }
+
+    public List<DistrictListResponse> getUserDistrictsByUserId(Long userId) {
+        List<UserDistrict> userDistricts = userDistrictFinder.findByUserIdFetchJoin(userId);
+
+        return userDistricts.stream()
+            .map(UserDistrict::getDistrict)
+            .filter(Objects::nonNull)
+            .map(DistrictListResponse::from)
+            .toList();  // Jav
     }
 }

--- a/src/main/java/com/trashheroesbe/feature/user/application/UserService.java
+++ b/src/main/java/com/trashheroesbe/feature/user/application/UserService.java
@@ -20,6 +20,8 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class UserService {
 
+    private static final String S3_USER_PREFIX = "user/";
+
     private final FileStoragePort fileStoragePort;
 
     private final UserFinder userFinder;
@@ -40,7 +42,11 @@ public class UserService {
 
             try {
                 imageUrl = fileStoragePort.uploadFile(
-                    fileName, image.getContentType(), image.getBytes());
+                    fileName,
+                    S3_USER_PREFIX,
+                    image.getContentType(),
+                    image.getBytes()
+                );
             } catch (Exception e) {
                 throw new BusinessException(S3_UPLOAD_FAIL);
             }

--- a/src/main/java/com/trashheroesbe/feature/user/application/UserService.java
+++ b/src/main/java/com/trashheroesbe/feature/user/application/UserService.java
@@ -1,0 +1,30 @@
+package com.trashheroesbe.feature.user.application;
+
+import com.trashheroesbe.feature.user.domain.entity.User;
+import com.trashheroesbe.feature.user.domain.service.UserFinder;
+import com.trashheroesbe.feature.user.dto.request.UpdateUserRequest;
+import com.trashheroesbe.feature.user.infrastructure.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserFinder userFinder;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void updateUser(UpdateUserRequest request, Long userId) {
+        User user = userFinder.findById(userId);
+
+        if (request.nickname() != null) {
+            user.updateNickname(request.nickname());
+        }
+
+
+
+    }
+}

--- a/src/main/java/com/trashheroesbe/feature/user/controller/UserController.java
+++ b/src/main/java/com/trashheroesbe/feature/user/controller/UserController.java
@@ -1,0 +1,33 @@
+package com.trashheroesbe.feature.user.controller;
+
+import static com.trashheroesbe.global.response.type.SuccessCode.OK;
+
+import com.trashheroesbe.feature.user.api.UserControllerApi;
+import com.trashheroesbe.feature.user.application.UserService;
+import com.trashheroesbe.feature.user.dto.request.UpdateUserRequest;
+import com.trashheroesbe.global.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController implements UserControllerApi {
+
+    private final UserService userService;
+
+    @Override
+    @PatchMapping("/{userId}")
+    public ApiResponse<Long> updateUser(
+        @RequestBody UpdateUserRequest request,
+        @PathVariable Long userId
+    ) {
+        userService.updateUser(request, userId);
+        return ApiResponse.success(OK, userId);
+    }
+}

--- a/src/main/java/com/trashheroesbe/feature/user/domain/AuthProvider.java
+++ b/src/main/java/com/trashheroesbe/feature/user/domain/AuthProvider.java
@@ -1,5 +1,0 @@
-package com.trashheroesbe.feature.user.domain;
-
-public enum AuthProvider {
-    LOCAL, KAKAO
-}

--- a/src/main/java/com/trashheroesbe/feature/user/domain/User.java
+++ b/src/main/java/com/trashheroesbe/feature/user/domain/User.java
@@ -1,8 +1,6 @@
 package com.trashheroesbe.feature.user.domain;
 
-import com.trashheroesbe.feature.trash.domain.Trash;
 import com.trashheroesbe.global.entity.BaseTimeEntity;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -52,4 +50,7 @@ public class User extends BaseTimeEntity {
     private List<Trash> trashList = new ArrayList<>();
 
 
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UserDistrict> userDistricts = new ArrayList<>();
 }

--- a/src/main/java/com/trashheroesbe/feature/user/domain/UserDistrict.java
+++ b/src/main/java/com/trashheroesbe/feature/user/domain/UserDistrict.java
@@ -1,0 +1,41 @@
+package com.trashheroesbe.feature.user.domain;
+
+import com.trashheroesbe.feature.district.domain.District;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "user_districts")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserDistrict {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "district_id", nullable = false)
+    private District district;
+
+    @Column
+    private Boolean isDefault = false;
+}

--- a/src/main/java/com/trashheroesbe/feature/user/domain/entity/User.java
+++ b/src/main/java/com/trashheroesbe/feature/user/domain/entity/User.java
@@ -1,6 +1,10 @@
 package com.trashheroesbe.feature.user.domain.entity;
 
+import com.trashheroesbe.feature.trash.domain.Trash;
+import com.trashheroesbe.feature.user.domain.type.AuthProvider;
+import com.trashheroesbe.feature.user.domain.type.Role;
 import com.trashheroesbe.global.entity.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/trashheroesbe/feature/user/domain/entity/User.java
+++ b/src/main/java/com/trashheroesbe/feature/user/domain/entity/User.java
@@ -1,4 +1,4 @@
-package com.trashheroesbe.feature.user.domain;
+package com.trashheroesbe.feature.user.domain.entity;
 
 import com.trashheroesbe.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
@@ -53,4 +53,16 @@ public class User extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserDistrict> userDistricts = new ArrayList<>();
+
+    public void updateNickname(String nickname) {
+        if (nickname != null && !nickname.isEmpty()) {
+            this.nickname = nickname;
+        }
+    }
+
+    public void updateProfileImageUrl(String profileImageUrl) {
+        if (profileImageUrl != null && !profileImageUrl.isEmpty()) {
+            this.profileImageUrl = profileImageUrl;
+        }
+    }
 }

--- a/src/main/java/com/trashheroesbe/feature/user/domain/entity/UserDistrict.java
+++ b/src/main/java/com/trashheroesbe/feature/user/domain/entity/UserDistrict.java
@@ -38,4 +38,12 @@ public class UserDistrict {
 
     @Column
     private Boolean isDefault = false;
+
+    public static UserDistrict createUserDistrict(User user, District district) {
+        return UserDistrict.builder()
+            .user(user)
+            .district(district)
+            .isDefault(false)
+            .build();
+    }
 }

--- a/src/main/java/com/trashheroesbe/feature/user/domain/entity/UserDistrict.java
+++ b/src/main/java/com/trashheroesbe/feature/user/domain/entity/UserDistrict.java
@@ -1,4 +1,4 @@
-package com.trashheroesbe.feature.user.domain;
+package com.trashheroesbe.feature.user.domain.entity;
 
 import com.trashheroesbe.feature.district.domain.District;
 import jakarta.persistence.Column;

--- a/src/main/java/com/trashheroesbe/feature/user/domain/entity/UserDistrict.java
+++ b/src/main/java/com/trashheroesbe/feature/user/domain/entity/UserDistrict.java
@@ -1,6 +1,6 @@
 package com.trashheroesbe.feature.user.domain.entity;
 
-import com.trashheroesbe.feature.district.domain.District;
+import com.trashheroesbe.feature.district.domain.entity.District;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/src/main/java/com/trashheroesbe/feature/user/domain/service/UserDistrictFinder.java
+++ b/src/main/java/com/trashheroesbe/feature/user/domain/service/UserDistrictFinder.java
@@ -1,7 +1,9 @@
 package com.trashheroesbe.feature.user.domain.service;
 
+import com.trashheroesbe.feature.user.domain.entity.UserDistrict;
 import com.trashheroesbe.feature.user.infrastructure.UserDistrictRepository;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,5 +17,13 @@ public class UserDistrictFinder {
 
     public Boolean existsByUserIdAndDistrictId(Long userId, String districtId) {
         return userDistrictRepository.existsByUserIdAndDistrictId(userId, districtId);
+    }
+
+    public Boolean existsByUserDistrictId(Long userDistrictId) {
+        return userDistrictRepository.existsById(userDistrictId);
+    }
+
+    public List<UserDistrict> findByUserId(Long userId) {
+        return userDistrictRepository.findByUserId(userId);
     }
 }

--- a/src/main/java/com/trashheroesbe/feature/user/domain/service/UserDistrictFinder.java
+++ b/src/main/java/com/trashheroesbe/feature/user/domain/service/UserDistrictFinder.java
@@ -1,0 +1,19 @@
+package com.trashheroesbe.feature.user.domain.service;
+
+import com.trashheroesbe.feature.user.infrastructure.UserDistrictRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserDistrictFinder {
+
+    private final UserDistrictRepository userDistrictRepository;
+
+    public Boolean existsByUserIdAndDistrictId(Long userId, String districtId) {
+        return userDistrictRepository.existsByUserIdAndDistrictId(userId, districtId);
+    }
+}

--- a/src/main/java/com/trashheroesbe/feature/user/domain/service/UserDistrictFinder.java
+++ b/src/main/java/com/trashheroesbe/feature/user/domain/service/UserDistrictFinder.java
@@ -26,4 +26,8 @@ public class UserDistrictFinder {
     public List<UserDistrict> findByUserId(Long userId) {
         return userDistrictRepository.findByUserId(userId);
     }
+
+    public List<UserDistrict> findByUserIdFetchJoin(Long userId) {
+        return userDistrictRepository.findByUserIdFetchJoin(userId);
+    }
 }

--- a/src/main/java/com/trashheroesbe/feature/user/domain/service/UserFinder.java
+++ b/src/main/java/com/trashheroesbe/feature/user/domain/service/UserFinder.java
@@ -1,0 +1,24 @@
+package com.trashheroesbe.feature.user.domain.service;
+
+import static com.trashheroesbe.global.response.type.ErrorCode.ENTITY_NOT_FOUND;
+
+import com.trashheroesbe.feature.user.domain.entity.User;
+import com.trashheroesbe.feature.user.infrastructure.UserRepository;
+import com.trashheroesbe.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserFinder {
+
+    private final UserRepository userRepository;
+
+    public User findById(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(ENTITY_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/trashheroesbe/feature/user/domain/type/AuthProvider.java
+++ b/src/main/java/com/trashheroesbe/feature/user/domain/type/AuthProvider.java
@@ -1,0 +1,5 @@
+package com.trashheroesbe.feature.user.domain.type;
+
+public enum AuthProvider {
+    LOCAL, KAKAO
+}

--- a/src/main/java/com/trashheroesbe/feature/user/domain/type/Role.java
+++ b/src/main/java/com/trashheroesbe/feature/user/domain/type/Role.java
@@ -1,4 +1,4 @@
-package com.trashheroesbe.feature.user.domain;
+package com.trashheroesbe.feature.user.domain.type;
 
 import java.util.Collection;
 import java.util.Set;

--- a/src/main/java/com/trashheroesbe/feature/user/dto/request/UpdateUserRequest.java
+++ b/src/main/java/com/trashheroesbe/feature/user/dto/request/UpdateUserRequest.java
@@ -4,10 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record UpdateUserRequest(
     @Schema(description = "닉네임", example = "수정닉네임")
-    String nickname,
-
-    @Schema(description = "선택한 자치구 Id(법정동코드)")
-    String districtId
+    String nickname
 ) {
 
 }

--- a/src/main/java/com/trashheroesbe/feature/user/dto/request/UpdateUserRequest.java
+++ b/src/main/java/com/trashheroesbe/feature/user/dto/request/UpdateUserRequest.java
@@ -1,0 +1,13 @@
+package com.trashheroesbe.feature.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UpdateUserRequest(
+    @Schema(description = "닉네임", example = "수정닉네임")
+    String nickname,
+
+    @Schema(description = "선택한 자치구 Id(법정동코드)")
+    String districtId
+) {
+
+}

--- a/src/main/java/com/trashheroesbe/feature/user/infrastructure/UserDistrictRepository.java
+++ b/src/main/java/com/trashheroesbe/feature/user/infrastructure/UserDistrictRepository.java
@@ -1,10 +1,14 @@
 package com.trashheroesbe.feature.user.infrastructure;
 
 import com.trashheroesbe.feature.user.domain.entity.UserDistrict;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserDistrictRepository extends JpaRepository<UserDistrict, Long> {
+
     Boolean existsByUserIdAndDistrictId(Long userId, String districtId);
+
+    List<UserDistrict> findByUserId(Long userId);
 }

--- a/src/main/java/com/trashheroesbe/feature/user/infrastructure/UserDistrictRepository.java
+++ b/src/main/java/com/trashheroesbe/feature/user/infrastructure/UserDistrictRepository.java
@@ -1,0 +1,10 @@
+package com.trashheroesbe.feature.user.infrastructure;
+
+import com.trashheroesbe.feature.user.domain.entity.UserDistrict;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserDistrictRepository extends JpaRepository<UserDistrict, Long> {
+    Boolean existsByUserIdAndDistrictId(Long userId, String districtId);
+}

--- a/src/main/java/com/trashheroesbe/feature/user/infrastructure/UserDistrictRepository.java
+++ b/src/main/java/com/trashheroesbe/feature/user/infrastructure/UserDistrictRepository.java
@@ -3,6 +3,7 @@ package com.trashheroesbe.feature.user.infrastructure;
 import com.trashheroesbe.feature.user.domain.entity.UserDistrict;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,4 +12,13 @@ public interface UserDistrictRepository extends JpaRepository<UserDistrict, Long
     Boolean existsByUserIdAndDistrictId(Long userId, String districtId);
 
     List<UserDistrict> findByUserId(Long userId);
+
+    @Query("""
+        SELECT ud 
+        FROM UserDistrict ud 
+        JOIN FETCH ud.district 
+        WHERE ud.user.id = :userId
+        """)
+    List<UserDistrict> findByUserIdFetchJoin(Long userId);
+
 }

--- a/src/main/java/com/trashheroesbe/feature/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/trashheroesbe/feature/user/infrastructure/UserRepository.java
@@ -1,6 +1,6 @@
 package com.trashheroesbe.feature.user.infrastructure;
 
-import com.trashheroesbe.feature.user.domain.User;
+import com.trashheroesbe.feature.user.domain.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/trashheroesbe/global/auth/security/CustomerDetails.java
+++ b/src/main/java/com/trashheroesbe/global/auth/security/CustomerDetails.java
@@ -1,6 +1,6 @@
 package com.trashheroesbe.global.auth.security;
 
-import com.trashheroesbe.feature.user.domain.User;
+import com.trashheroesbe.feature.user.domain.entity.User;
 import java.util.Collection;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/trashheroesbe/global/auth/security/CustomerDetailsService.java
+++ b/src/main/java/com/trashheroesbe/global/auth/security/CustomerDetailsService.java
@@ -1,6 +1,6 @@
 package com.trashheroesbe.global.auth.security;
 
-import com.trashheroesbe.feature.user.domain.User;
+import com.trashheroesbe.feature.user.domain.entity.User;
 import com.trashheroesbe.feature.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/java/com/trashheroesbe/global/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/trashheroesbe/global/auth/service/CustomOAuth2UserService.java
@@ -1,13 +1,11 @@
 package com.trashheroesbe.global.auth.service;
 
-import com.trashheroesbe.feature.user.domain.AuthProvider;
-import com.trashheroesbe.feature.user.domain.Role;
+import com.trashheroesbe.feature.user.domain.type.AuthProvider;
+import com.trashheroesbe.feature.user.domain.type.Role;
 import com.trashheroesbe.feature.user.domain.User;
 import com.trashheroesbe.feature.user.infrastructure.UserRepository;
-import java.util.Collections;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;

--- a/src/main/java/com/trashheroesbe/global/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/trashheroesbe/global/auth/service/CustomOAuth2UserService.java
@@ -2,7 +2,7 @@ package com.trashheroesbe.global.auth.service;
 
 import com.trashheroesbe.feature.user.domain.type.AuthProvider;
 import com.trashheroesbe.feature.user.domain.type.Role;
-import com.trashheroesbe.feature.user.domain.User;
+import com.trashheroesbe.feature.user.domain.entity.User;
 import com.trashheroesbe.feature.user.infrastructure.UserRepository;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/trashheroesbe/global/response/type/ErrorCode.java
+++ b/src/main/java/com/trashheroesbe/global/response/type/ErrorCode.java
@@ -22,6 +22,8 @@ public enum ErrorCode {
     // s3
     S3_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 업로드에 실패했습니다."),
 
+    // user
+    DUPLICATE_USER_DISTRICT(HttpStatus.BAD_REQUEST, "중복된 자치구 입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/trashheroesbe/global/response/type/ErrorCode.java
+++ b/src/main/java/com/trashheroesbe/global/response/type/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
 
     // s3
     S3_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 업로드에 실패했습니다."),
+
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/trashheroesbe/global/response/type/ErrorCode.java
+++ b/src/main/java/com/trashheroesbe/global/response/type/ErrorCode.java
@@ -11,6 +11,8 @@ public enum ErrorCode {
     // common
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "입력값 검증에 실패했습니다."),
+    ENTITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "요청한 정보로 엔터티를 찾을 수 없습니다."),
+    ACCESS_DENIED_EXCEPTION(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다."),
 
     // auth
     NOT_EXISTS_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),

--- a/src/main/java/com/trashheroesbe/global/response/type/ErrorCode.java
+++ b/src/main/java/com/trashheroesbe/global/response/type/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
 
     // user
     DUPLICATE_USER_DISTRICT(HttpStatus.BAD_REQUEST, "중복된 자치구 입니다."),
+    MAX_USER_DISTRICTS_EXCEEDED(HttpStatus.BAD_REQUEST, "자치구는 최대 2개만 가질 수 있습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/trashheroesbe/global/util/FileUtils.java
+++ b/src/main/java/com/trashheroesbe/global/util/FileUtils.java
@@ -1,0 +1,25 @@
+package com.trashheroesbe.global.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+public class FileUtils {
+
+    /**
+     * 저장될 파일명을 생성합니다. 형식: trash/YYYYMMDD_HHmmss_UUID_확장자
+     */
+    public static String generateStoredFileName(String originalFileName) {
+        String timestamp = LocalDateTime.now()
+            .format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+        String uuid = UUID.randomUUID().toString().substring(0, 8);
+
+        String extension = "";
+        int lastDotIndex = originalFileName.lastIndexOf(".");
+        if (lastDotIndex > 0) {
+            extension = originalFileName.substring(lastDotIndex);
+        }
+
+        return String.format("trash/%s_%s%s", timestamp, uuid, extension);
+    }
+}

--- a/src/main/java/com/trashheroesbe/infrastructure/adapter/out/s3/S3FileAdapter.java
+++ b/src/main/java/com/trashheroesbe/infrastructure/adapter/out/s3/S3FileAdapter.java
@@ -23,20 +23,25 @@ public class S3FileAdapter implements FileStoragePort {
     private String region;
 
     @Override
-    public String uploadFile(String fileName, String contentType, byte[] fileData) {
+    public String uploadFile(
+        String fileName,
+        String pathPrefix,
+        String contentType,
+        byte[] fileData
+    ) {
         log.info("S3 파일 업로드 시작: bucket={}, fileName={}", bucketName, fileName);
 
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                    .bucket(bucketName)
-                    .key(fileName)
-                    .contentType(contentType)
-                    .build();
+                .bucket(bucketName)
+                .key(fileName)
+                .contentType(contentType)
+                .build();
 
             s3Client.putObject(putObjectRequest, RequestBody.fromBytes(fileData));
 
             String fileUrl = String.format("https://%s.s3.%s.amazonaws.com/%s",
-                    bucketName, region, fileName);
+                bucketName, region, fileName);
 
             log.info("S3 파일 업로드 완료: {}", fileUrl);
             return fileUrl;

--- a/src/main/java/com/trashheroesbe/infrastructure/adapter/out/s3/S3FileAdapter.java
+++ b/src/main/java/com/trashheroesbe/infrastructure/adapter/out/s3/S3FileAdapter.java
@@ -1,6 +1,6 @@
-package com.trashheroesbe.global.s3.infrastructure;
+package com.trashheroesbe.infrastructure.adapter.out.s3;
 
-import com.trashheroesbe.global.s3.application.FileStorageService;
+import com.trashheroesbe.infrastructure.port.s3.FileStoragePort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,7 +12,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class S3FileStorageService implements FileStorageService {
+public class S3FileAdapter implements FileStoragePort {
 
     private final S3Client s3Client;
 

--- a/src/main/java/com/trashheroesbe/infrastructure/port/s3/FileStoragePort.java
+++ b/src/main/java/com/trashheroesbe/infrastructure/port/s3/FileStoragePort.java
@@ -1,6 +1,6 @@
-package com.trashheroesbe.global.s3.application;
+package com.trashheroesbe.infrastructure.port.s3;
 
-public interface FileStorageService {
+public interface FileStoragePort {
 
     /**
      * 파일을 저장소에 업로드합니다.

--- a/src/main/java/com/trashheroesbe/infrastructure/port/s3/FileStoragePort.java
+++ b/src/main/java/com/trashheroesbe/infrastructure/port/s3/FileStoragePort.java
@@ -5,10 +5,15 @@ public interface FileStoragePort {
     /**
      * 파일을 저장소에 업로드합니다.
      *
-     * @param fileName 저장할 파일명
+     * @param fileName    저장할 파일명
      * @param contentType 파일 콘텐츠 타입
-     * @param fileData 파일 데이터
+     * @param fileData    파일 데이터
      * @return 업로드된 파일의 URL
      */
-    String uploadFile(String fileName, String contentType, byte[] fileData);
+    String uploadFile(
+        String fileName,
+        String pathPrefix,
+        String contentType,
+        byte[] fileData
+    );
 }


### PR DESCRIPTION
## ✅ 작업 내용
- 유저 정보 수정 구현하였습니다. (nickname, profileImage)
- 유저 자치구 추가 구현하였습니다.(최대 2개)
- 유저 자치구 삭제 구현하였습니다.
- 로그인한 유저의 자치구 조회 구현하였습니다.
- 자치구 검색 구현하였습니다.

## 🤔 고민 했던 부분
-

## 🚨 참고 사항
- 법정동코드를 더미데이터로 디비에 직접 넣어야 하기 때문에 테이블 create-drop하면 초기 데이터가 없습니다. 참고부탁드립니다!

## 🔊 도움이 필요한 부분
- 

## 🚀 기대 효과
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 쓰레기 업로드(이미지 S3 저장) 및 내 쓰레기 조회 API 추가
  - 자치구 조회 API 추가(시도/시군구 기준)
  - 사용자 프로필 수정(닉네임/프로필 이미지 업로드) 및 내 자치구 관리(추가/삭제/조회)
  - 에러 코드 확장(S3 업로드 실패, 중복/최대 자치구, 엔티티 없음 등)으로 응답 메시지 개선
- Refactor
  - 사용자/인증 패키지 구조 정리 및 타입 분리로 모듈화 개선
- Chores
  - 배포 워크플로우에 cloud 설정 파일 주입 추가
  - .gitignore 패턴 단일화 및 AI 리뷰 설정 추가
  - JPA Auditing 활성화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->