### PR TITLE
Feat: OCI Object Storage(S3 호환) 전환 및 업로드 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
-!/.idea/
 
 application*.yml
-
 

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 디폴트 무시된 파일
+/shelf/
+/workspace.xml
+# 에디터 기반 HTTP 클라이언트 요청
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+trash-heroes-be

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -4,9 +4,6 @@
     <annotationProcessing>
       <profile name="Gradle Imported" enabled="true">
         <outputRelativeToContentRoot value="true" />
-        <processorPath useClasspath="false">
-          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.38/57f8f5e02e92a30fd21b80cbd426a4172b5f8e29/lombok-1.18.38.jar" />
-        </processorPath>
         <module name="trash-heroes-be.main" />
       </profile>
     </annotationProcessing>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.38/57f8f5e02e92a30fd21b80cbd426a4172b5f8e29/lombok-1.18.38.jar" />
+        </processorPath>
+        <module name="trash-heroes-be.main" />
+      </profile>
+    </annotationProcessing>
+    <bytecodeTargetLevel target="21" />
+  </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_STRING" value="-parameters" />
+  </component>
+</project>

--- a/.idea/discord.xml
+++ b/.idea/discord.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DiscordProjectSettings">
+    <option name="show" value="ASK" />
+    <option name="description" value="" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="#JAVA_HOME" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/trash-heroes-be.main.iml" filepath="$PROJECT_DIR$/.idea/modules/trash-heroes-be.main.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/uiDesigner.xml
+++ b/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.svg" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
     // s3
-    implementation "io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.0"
+    implementation "software.amazon.awssdk:s3:2.31.54"
 
     // openai
     implementation 'org.springframework.ai:spring-ai-starter-model-openai'

--- a/src/main/java/com/trashheroesbe/global/config/ObjectStorageConfig.java
+++ b/src/main/java/com/trashheroesbe/global/config/ObjectStorageConfig.java
@@ -6,8 +6,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
 
 @Configuration
@@ -19,9 +22,10 @@ public class ObjectStorageConfig {
         @Value("${storage.s3.region}") String region,
         @Value("${storage.s3.access-key}") String accessKey,
         @Value("${storage.s3.secret-key}") String secretKey,
-        @Value("${storage.s3.path-style-access:true}") boolean pathStyleAccess
+        @Value("${storage.s3.path-style-access:true}") boolean pathStyleAccess,
+        @Value("${storage.s3.checksum-validation-enabled:false}") boolean checksumValidationEnabled
     ) {
-        return S3Client.builder()
+        S3ClientBuilder builder = S3Client.builder()
             .endpointOverride(URI.create(endpoint))
             .region(Region.of(region))
             .credentialsProvider(
@@ -33,9 +37,14 @@ public class ObjectStorageConfig {
                 S3Configuration.builder()
                     .pathStyleAccessEnabled(pathStyleAccess)
                     .chunkedEncodingEnabled(false)
-                    .checksumValidationEnabled(false)
                     .build()
-            )
-            .build();
+            );
+
+        if (checksumValidationEnabled) {
+            builder.requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
+            builder.responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
+        }
+
+        return builder.build();
     }
 }

--- a/src/main/java/com/trashheroesbe/global/config/ObjectStorageConfig.java
+++ b/src/main/java/com/trashheroesbe/global/config/ObjectStorageConfig.java
@@ -1,0 +1,41 @@
+package com.trashheroesbe.global.config;
+
+import java.net.URI;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+@Configuration
+public class ObjectStorageConfig {
+
+    @Bean
+    public S3Client s3Client(
+        @Value("${storage.s3.endpoint}") String endpoint,
+        @Value("${storage.s3.region}") String region,
+        @Value("${storage.s3.access-key}") String accessKey,
+        @Value("${storage.s3.secret-key}") String secretKey,
+        @Value("${storage.s3.path-style-access:true}") boolean pathStyleAccess
+    ) {
+        return S3Client.builder()
+            .endpointOverride(URI.create(endpoint))
+            .region(Region.of(region))
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKey, secretKey)
+                )
+            )
+            .serviceConfiguration(
+                S3Configuration.builder()
+                    .pathStyleAccessEnabled(pathStyleAccess)
+                    .chunkedEncodingEnabled(false)
+                    .checksumValidationEnabled(false)
+                    .build()
+            )
+            .build();
+    }
+}

--- a/src/main/java/com/trashheroesbe/infrastructure/adapter/out/s3/S3FileStorageAdapter.java
+++ b/src/main/java/com/trashheroesbe/infrastructure/adapter/out/s3/S3FileStorageAdapter.java
@@ -19,11 +19,11 @@ public class S3FileStorageAdapter implements FileStoragePort {
 
     private final S3Client s3Client;
 
-    @Value("${spring.cloud.aws.s3.bucket}")
+    @Value("${storage.s3.bucket}")
     private String bucketName;
 
-    @Value("${spring.cloud.aws.region.static}")
-    private String region;
+    @Value("${storage.s3.public-base-url}")
+    private String publicBaseUrl;
 
     @Override
     public String uploadFile(String key, String contentType, byte[] fileData) {
@@ -37,7 +37,7 @@ public class S3FileStorageAdapter implements FileStoragePort {
 
         s3Client.putObject(put, RequestBody.fromBytes(fileData));
 
-        String url = String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, key);
+        String url = String.format("%s/%s", trimTrailingSlash(publicBaseUrl), key);
         log.info("S3 파일 업로드 완료: {}", url);
         return url;
     }
@@ -66,19 +66,33 @@ public class S3FileStorageAdapter implements FileStoragePort {
     }
 
     private String extractKeyFromUrl(String fileUrl) {
-        try {
-            String path = URI.create(fileUrl).getPath();           // /trash/2025.../abc.jpg
-            return path.startsWith("/") ? path.substring(1) : path; // trash/2025.../abc.jpg
-        } catch (Exception e) {
-            // 도메인이 변형된 경우를 위한 보정
-            final String marker = ".amazonaws.com/";
-            int idx = fileUrl.indexOf(marker);
-            if (idx >= 0) {
-                return fileUrl.substring(idx + marker.length());
-            }
-            int slash = fileUrl.indexOf('/', fileUrl.indexOf("://") + 3);
-            return (slash >= 0 && slash + 1 < fileUrl.length()) ? fileUrl.substring(slash + 1)
-                : fileUrl;
+        String normalizedBaseUrl = trimTrailingSlash(publicBaseUrl);
+        if (fileUrl != null && fileUrl.startsWith(normalizedBaseUrl + "/")) {
+            return fileUrl.substring(normalizedBaseUrl.length() + 1);
         }
+
+        try {
+            String path = URI.create(fileUrl).getPath();
+            String normalizedPath = path.startsWith("/") ? path.substring(1) : path;
+            String bucketPrefix = bucketName + "/";
+            return normalizedPath.startsWith(bucketPrefix)
+                ? normalizedPath.substring(bucketPrefix.length())
+                : normalizedPath;
+        } catch (Exception e) {
+            int slash = fileUrl.indexOf('/', fileUrl.indexOf("://") + 3);
+            String fallback = (slash >= 0 && slash + 1 < fileUrl.length())
+                ? fileUrl.substring(slash + 1)
+                : fileUrl;
+            String bucketPrefix = bucketName + "/";
+            return fallback.startsWith(bucketPrefix)
+                ? fallback.substring(bucketPrefix.length())
+                : fallback;
+        }
+    }
+
+    private String trimTrailingSlash(String value) {
+        return value != null && value.endsWith("/")
+            ? value.substring(0, value.length() - 1)
+            : value;
     }
 }

--- a/src/main/java/com/trashheroesbe/infrastructure/adapter/out/s3/S3FileStorageAdapter.java
+++ b/src/main/java/com/trashheroesbe/infrastructure/adapter/out/s3/S3FileStorageAdapter.java
@@ -66,28 +66,39 @@ public class S3FileStorageAdapter implements FileStoragePort {
     }
 
     private String extractKeyFromUrl(String fileUrl) {
+        if (fileUrl == null || fileUrl.isBlank()) {
+            throw new IllegalArgumentException("삭제할 파일 URL이 비어 있습니다.");
+        }
+
+        String normalizedFileUrl = fileUrl.trim();
         String normalizedBaseUrl = trimTrailingSlash(publicBaseUrl);
-        if (fileUrl != null && fileUrl.startsWith(normalizedBaseUrl + "/")) {
-            return fileUrl.substring(normalizedBaseUrl.length() + 1);
+        String allowedUrlPrefix = normalizedBaseUrl + "/";
+        String bucketPrefix = bucketName + "/";
+
+        if (normalizedFileUrl.startsWith(allowedUrlPrefix)) {
+            return normalizedFileUrl.substring(allowedUrlPrefix.length());
+        }
+
+        if (normalizedFileUrl.startsWith(bucketPrefix)) {
+            return normalizedFileUrl.substring(bucketPrefix.length());
         }
 
         try {
-            String path = URI.create(fileUrl).getPath();
+            String path = URI.create(normalizedFileUrl).getPath();
             String normalizedPath = path.startsWith("/") ? path.substring(1) : path;
-            String bucketPrefix = bucketName + "/";
-            return normalizedPath.startsWith(bucketPrefix)
-                ? normalizedPath.substring(bucketPrefix.length())
-                : normalizedPath;
+            if (!normalizedPath.startsWith(bucketPrefix)) {
+                throw invalidFileUrl(normalizedFileUrl);
+            }
+            return normalizedPath.substring(bucketPrefix.length());
         } catch (Exception e) {
-            int slash = fileUrl.indexOf('/', fileUrl.indexOf("://") + 3);
-            String fallback = (slash >= 0 && slash + 1 < fileUrl.length())
-                ? fileUrl.substring(slash + 1)
-                : fileUrl;
-            String bucketPrefix = bucketName + "/";
-            return fallback.startsWith(bucketPrefix)
-                ? fallback.substring(bucketPrefix.length())
-                : fallback;
+            throw e instanceof IllegalArgumentException
+                ? (IllegalArgumentException) e
+                : invalidFileUrl(normalizedFileUrl);
         }
+    }
+
+    private IllegalArgumentException invalidFileUrl(String fileUrl) {
+        return new IllegalArgumentException("허용되지 않은 스토리지 파일 URL입니다: " + fileUrl);
     }
 
     private String trimTrailingSlash(String value) {


### PR DESCRIPTION
## ✅ 작업 내용
* 기존 AWS S3 기반 파일 저장소를 OCI Object Storage의 S3 호환 방식으로 전환했습니다.
* application-cloud.yml의 스토리지 설정을 OCI 기준으로 정리하고, 액세스 키/시크릿 키는 환경 변수로 주입받도록 변경했습니다.
* spring-cloud-aws 의존 대신 AWS SDK S3Client를 직접 생성하는 방식으로 변경했습니다.
* OCI S3 호환 endpoint에 맞게 S3Client 설정을 추가했습니다.
* 업로드 URL 생성 방식을 AWS 전용 URL 형식에서 OCI public base URL 기반으로 변경했습니다.
* 파일 삭제 시 URL에서 object key를 추출하는 로직을 OCI path-style URL 기준에 맞게 수정했습니다.
* 실제 업로드 테스트를 통해 OCI 버킷에 객체가 정상 저장되는 것까지 확인했습니다.

## 🤔 고민 했던 부분
* OCI 전용 SDK를 사용할지, S3 호환 방식을 사용할지 고민했습니다.
* 현재 프로젝트는 FileStoragePort로 스토리지 접근이 추상화되어 있고, 업로드/삭제 동작이 단순해서 변경 범위를 최소화하는 것이 중요하다고 판단했습니다.
* 그 결과 OCI 전용 SDK 대신 S3 호환 방식을 선택했고, 비즈니스 로직 수정 없이 인프라 레이어와 설정 중심으로 전환했습니다.
* 업로드 과정에서 OCI가 AWS chunked encoding을 지원하지 않아 업로드가 실패하는 이슈가 있었고, S3Client 설정에서 chunked encoding을 비활성화하는 방식으로 해결했습니다.

## 🚨 참고 사항
* OCI Object Storage는 public bucket 기준으로 운영하고 있어 업로드된 파일 URL을 그대로 클라이언트에서 사용할 수 있습니다.
* [참고자료](https://docs.oracle.com/en-us/iaas/Content/Object/home.htm)
* #69 

## 🚀 기대 효과
* AWS S3 의존성을 제거하고 OCI Object Storage로 스토리지 비용 및 운영 환경을 일원화할 수 있습니다.
* 기존 파일 업로드 기능(유저 이미지, 파트너 이미지, 쓰레기 이미지, 쿠폰 QR)을 큰 구조 변경 없이 유지할 수 있습니다.
* 스토리지 구현이 FileStoragePort 뒤에 유지되어 있어 이후 다른 객체 스토리지로의 전환도 비교적 쉽게 대응할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 개발 환경용 IDE 설정 파일 추가

* **Refactor**
  * 객체 스토리지(S3) 클라이언트 구성 개선
  * 공개 파일 URL 생성 및 키 추출 방식 변경으로 외부 접근 경로가 더 일관되게 생성됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->