### PR TITLE
Test: 도메인·서비스·어댑터 단위 테스트 도입 및 테스트로 발견한 버그 3건 수정

### DIFF
--- a/src/main/java/com/trashheroesbe/feature/coupon/application/CouponService.java
+++ b/src/main/java/com/trashheroesbe/feature/coupon/application/CouponService.java
@@ -123,6 +123,9 @@ public class CouponService {
 
         UserCoupon userCoupon = userCouponRepository.findById(userCouponId)
             .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
+        if (!userCoupon.getCoupon().getPartner().getId().equals(partner.getId())) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED_EXCEPTION);
+        }
         userCoupon.useCoupon();
     }
 

--- a/src/main/java/com/trashheroesbe/feature/trash/application/TrashService.java
+++ b/src/main/java/com/trashheroesbe/feature/trash/application/TrashService.java
@@ -438,7 +438,7 @@ public class TrashService {
 
         trash.applyItem(item);
 
-        if (item.getItemType() == ItemType.CAUTION && item.getTrashType() != null) {
+        if (item.getItemType() == ItemType.CAUTION && item.getRedirectTrashType() != null) {
             trash.applyAnalysis(item.getRedirectTrashType());
         }
 

--- a/src/main/java/com/trashheroesbe/infrastructure/adapter/out/gpt/OpenAIChatAdapter.java
+++ b/src/main/java/com/trashheroesbe/infrastructure/adapter/out/gpt/OpenAIChatAdapter.java
@@ -215,6 +215,8 @@ public class OpenAIChatAdapter implements ChatAIClientPort {
 
             return parseSimilarItemNameResponse(gptResponse);
 
+        } catch (BusinessException e) {
+            throw e;
         } catch (Exception e) {
             throw new BusinessException(ERROR_GPT_CALL);
         }

--- a/src/main/java/com/trashheroesbe/infrastructure/adapter/out/s3/S3FileStorageAdapter.java
+++ b/src/main/java/com/trashheroesbe/infrastructure/adapter/out/s3/S3FileStorageAdapter.java
@@ -84,7 +84,12 @@ public class S3FileStorageAdapter implements FileStoragePort {
         }
 
         try {
-            String path = URI.create(normalizedFileUrl).getPath();
+            URI fileUri = URI.create(normalizedFileUrl);
+            String allowedHost = URI.create(normalizedBaseUrl).getHost();
+            if (fileUri.getHost() == null || !fileUri.getHost().equals(allowedHost)) {
+                throw invalidFileUrl(normalizedFileUrl);
+            }
+            String path = fileUri.getPath();
             String normalizedPath = path.startsWith("/") ? path.substring(1) : path;
             if (!normalizedPath.startsWith(bucketPrefix)) {
                 throw invalidFileUrl(normalizedFileUrl);

--- a/src/test/java/com/trashheroesbe/TrashHeroesBeApplicationTests.java
+++ b/src/test/java/com/trashheroesbe/TrashHeroesBeApplicationTests.java
@@ -1,8 +1,10 @@
 package com.trashheroesbe;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+@Disabled("로컬 MySQL 등 외부 인프라 없이는 컨텍스트 로드가 불가능. Testcontainers 기반 통합 테스트 환경 구성 시 활성화 예정")
 @SpringBootTest
 class TrashHeroesBeApplicationTests {
 

--- a/src/test/java/com/trashheroesbe/feature/coupon/application/CouponServiceTest.java
+++ b/src/test/java/com/trashheroesbe/feature/coupon/application/CouponServiceTest.java
@@ -57,6 +57,7 @@ class CouponServiceTest {
         @Test
         @DisplayName("인증 정보가 없으면 ACCESS_DENIED 예외가 발생한다")
         void 인증_정보_없음() {
+            // when & then
             assertThatThrownBy(() -> couponService.getPartnerCoupons(null))
                 .isInstanceOfSatisfying(BusinessException.class, e ->
                     assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_EXCEPTION));
@@ -65,8 +66,10 @@ class CouponServiceTest {
         @Test
         @DisplayName("파트너가 연결되지 않은 일반 사용자는 ACCESS_DENIED 예외가 발생한다")
         void 일반_사용자_접근_불가() {
+            // given
             CustomerDetails userDetails = new CustomerDetails(UserFixture.user(3L));
 
+            // when & then
             assertThatThrownBy(() -> couponService.getPartnerCoupons(userDetails))
                 .isInstanceOfSatisfying(BusinessException.class, e ->
                     assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_EXCEPTION));
@@ -80,13 +83,16 @@ class CouponServiceTest {
         @Test
         @DisplayName("자기 파트너 소속 쿠폰 목록을 응답으로 변환한다")
         void 쿠폰_목록_조회() {
+            // given
             Coupon coupon = CouponFixture.coupon(10L, myPartner);
             given(couponRepository.findAllByPartnerIdFetch(myPartner.getId()))
                 .willReturn(List.of(coupon));
 
+            // when
             List<PartnerCouponResponse> responses =
                 couponService.getPartnerCoupons(partnerDetails);
 
+            // then
             assertThat(responses).hasSize(1);
             assertThat(responses.get(0).couponId()).isEqualTo(10L);
             assertThat(responses.get(0).title()).isEqualTo(coupon.getTitle());
@@ -100,20 +106,25 @@ class CouponServiceTest {
         @Test
         @DisplayName("자기 파트너의 쿠폰은 삭제할 수 있다")
         void 본인_쿠폰_삭제() {
+            // given
             Coupon coupon = CouponFixture.coupon(10L, myPartner);
             given(couponRepository.findByIdFetchPartner(10L)).willReturn(Optional.of(coupon));
 
+            // when
             couponService.deleteCoupon(partnerDetails, 10L);
 
+            // then
             verify(couponRepository).delete(coupon);
         }
 
         @Test
         @DisplayName("다른 파트너의 쿠폰을 삭제하면 ACCESS_DENIED 예외가 발생한다")
         void 다른_파트너_쿠폰_삭제_불가() {
+            // given
             Coupon coupon = CouponFixture.coupon(10L, otherPartner);
             given(couponRepository.findByIdFetchPartner(10L)).willReturn(Optional.of(coupon));
 
+            // when & then
             assertThatThrownBy(() -> couponService.deleteCoupon(partnerDetails, 10L))
                 .isInstanceOfSatisfying(BusinessException.class, e ->
                     assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_EXCEPTION));
@@ -123,8 +134,10 @@ class CouponServiceTest {
         @Test
         @DisplayName("존재하지 않는 쿠폰이면 ENTITY_NOT_FOUND 예외가 발생한다")
         void 쿠폰_없음() {
+            // given
             given(couponRepository.findByIdFetchPartner(anyLong())).willReturn(Optional.empty());
 
+            // when & then
             assertThatThrownBy(() -> couponService.deleteCoupon(partnerDetails, 99L))
                 .isInstanceOfSatisfying(BusinessException.class, e ->
                     assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ENTITY_NOT_FOUND));
@@ -138,14 +151,17 @@ class CouponServiceTest {
         @Test
         @DisplayName("자기 파트너의 쿠폰 정보를 수정한다")
         void 본인_쿠폰_수정() {
+            // given
             Coupon coupon = CouponFixture.coupon(10L, myPartner);
             given(couponRepository.findByIdFetchPartner(10L)).willReturn(Optional.of(coupon));
             CouponUpdateRequest request = new CouponUpdateRequest(
                 "수정된 제목", null, null, null, null, null, null, null);
 
+            // when
             CouponCreateResponse response =
                 couponService.updateCoupon(partnerDetails, 10L, request);
 
+            // then
             assertThat(coupon.getTitle()).isEqualTo("수정된 제목");
             assertThat(response.title()).isEqualTo("수정된 제목");
             assertThat(response.couponId()).isEqualTo(10L);
@@ -154,11 +170,13 @@ class CouponServiceTest {
         @Test
         @DisplayName("다른 파트너의 쿠폰을 수정하면 ACCESS_DENIED 예외가 발생하고 값이 유지된다")
         void 다른_파트너_쿠폰_수정_불가() {
+            // given
             Coupon coupon = CouponFixture.coupon(10L, otherPartner);
             given(couponRepository.findByIdFetchPartner(10L)).willReturn(Optional.of(coupon));
             CouponUpdateRequest request = new CouponUpdateRequest(
                 "수정된 제목", null, null, null, null, null, null, null);
 
+            // when & then
             assertThatThrownBy(() -> couponService.updateCoupon(partnerDetails, 10L, request))
                 .isInstanceOfSatisfying(BusinessException.class, e ->
                     assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_EXCEPTION));
@@ -173,12 +191,15 @@ class CouponServiceTest {
         @Test
         @DisplayName("보유 쿠폰을 사용 완료 상태로 전이시킨다")
         void 쿠폰_사용() {
+            // given
             Coupon coupon = CouponFixture.coupon(10L, myPartner);
             UserCoupon userCoupon = UserCoupon.create(UserFixture.user(5L), coupon);
             given(userCouponRepository.findById(100L)).willReturn(Optional.of(userCoupon));
 
+            // when
             couponService.useCoupon(partnerDetails, 100L);
 
+            // then
             assertThat(userCoupon.getStatus()).isEqualTo(CouponStatus.USED);
             assertThat(userCoupon.getUsedAt()).isNotNull();
         }
@@ -186,8 +207,10 @@ class CouponServiceTest {
         @Test
         @DisplayName("존재하지 않는 보유 쿠폰이면 ENTITY_NOT_FOUND 예외가 발생한다")
         void 보유_쿠폰_없음() {
+            // given
             given(userCouponRepository.findById(anyLong())).willReturn(Optional.empty());
 
+            // when & then
             assertThatThrownBy(() -> couponService.useCoupon(partnerDetails, 99L))
                 .isInstanceOfSatisfying(BusinessException.class, e ->
                     assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ENTITY_NOT_FOUND));
@@ -197,10 +220,12 @@ class CouponServiceTest {
         @Disabled("버그 재현: useCoupon은 쿠폰이 요청 파트너 소속인지 검증하지 않아 다른 파트너의 쿠폰도 사용 처리된다. 소유권 검증 추가(fix) 후 활성화 예정")
         @DisplayName("다른 파트너 소속 쿠폰을 사용하면 ACCESS_DENIED 예외가 발생해야 한다")
         void 다른_파트너_쿠폰_사용_불가() {
+            // given
             Coupon coupon = CouponFixture.coupon(10L, otherPartner);
             UserCoupon userCoupon = UserCoupon.create(UserFixture.user(5L), coupon);
             given(userCouponRepository.findById(100L)).willReturn(Optional.of(userCoupon));
 
+            // when & then
             assertThatThrownBy(() -> couponService.useCoupon(partnerDetails, 100L))
                 .isInstanceOfSatisfying(BusinessException.class, e ->
                     assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_EXCEPTION));

--- a/src/test/java/com/trashheroesbe/feature/coupon/application/CouponServiceTest.java
+++ b/src/test/java/com/trashheroesbe/feature/coupon/application/CouponServiceTest.java
@@ -1,0 +1,210 @@
+package com.trashheroesbe.feature.coupon.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.trashheroesbe.feature.coupon.domain.entity.Coupon;
+import com.trashheroesbe.feature.coupon.domain.entity.UserCoupon;
+import com.trashheroesbe.feature.coupon.domain.type.CouponStatus;
+import com.trashheroesbe.feature.coupon.dto.request.CouponUpdateRequest;
+import com.trashheroesbe.feature.coupon.dto.response.CouponCreateResponse;
+import com.trashheroesbe.feature.coupon.dto.response.PartnerCouponResponse;
+import com.trashheroesbe.feature.coupon.infrastructure.CouponRepository;
+import com.trashheroesbe.feature.coupon.infrastructure.UserCouponRepository;
+import com.trashheroesbe.feature.partner.domain.entity.Partner;
+import com.trashheroesbe.fixture.CouponFixture;
+import com.trashheroesbe.fixture.PartnerFixture;
+import com.trashheroesbe.fixture.UserFixture;
+import com.trashheroesbe.global.auth.security.CustomerDetails;
+import com.trashheroesbe.global.exception.BusinessException;
+import com.trashheroesbe.global.response.type.ErrorCode;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CouponServiceTest {
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @Mock
+    private UserCouponRepository userCouponRepository;
+
+    @InjectMocks
+    private CouponService couponService;
+
+    private final Partner myPartner = PartnerFixture.partner(1L);
+    private final Partner otherPartner = PartnerFixture.partner(2L);
+    private final CustomerDetails partnerDetails =
+        new CustomerDetails(UserFixture.partnerUser(1L, myPartner));
+
+    @Nested
+    @DisplayName("파트너 권한 검증")
+    class ExtractPartner {
+
+        @Test
+        @DisplayName("인증 정보가 없으면 ACCESS_DENIED 예외가 발생한다")
+        void 인증_정보_없음() {
+            assertThatThrownBy(() -> couponService.getPartnerCoupons(null))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_EXCEPTION));
+        }
+
+        @Test
+        @DisplayName("파트너가 연결되지 않은 일반 사용자는 ACCESS_DENIED 예외가 발생한다")
+        void 일반_사용자_접근_불가() {
+            CustomerDetails userDetails = new CustomerDetails(UserFixture.user(3L));
+
+            assertThatThrownBy(() -> couponService.getPartnerCoupons(userDetails))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_EXCEPTION));
+        }
+    }
+
+    @Nested
+    @DisplayName("getPartnerCoupons")
+    class GetPartnerCoupons {
+
+        @Test
+        @DisplayName("자기 파트너 소속 쿠폰 목록을 응답으로 변환한다")
+        void 쿠폰_목록_조회() {
+            Coupon coupon = CouponFixture.coupon(10L, myPartner);
+            given(couponRepository.findAllByPartnerIdFetch(myPartner.getId()))
+                .willReturn(List.of(coupon));
+
+            List<PartnerCouponResponse> responses =
+                couponService.getPartnerCoupons(partnerDetails);
+
+            assertThat(responses).hasSize(1);
+            assertThat(responses.get(0).couponId()).isEqualTo(10L);
+            assertThat(responses.get(0).title()).isEqualTo(coupon.getTitle());
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteCoupon")
+    class DeleteCoupon {
+
+        @Test
+        @DisplayName("자기 파트너의 쿠폰은 삭제할 수 있다")
+        void 본인_쿠폰_삭제() {
+            Coupon coupon = CouponFixture.coupon(10L, myPartner);
+            given(couponRepository.findByIdFetchPartner(10L)).willReturn(Optional.of(coupon));
+
+            couponService.deleteCoupon(partnerDetails, 10L);
+
+            verify(couponRepository).delete(coupon);
+        }
+
+        @Test
+        @DisplayName("다른 파트너의 쿠폰을 삭제하면 ACCESS_DENIED 예외가 발생한다")
+        void 다른_파트너_쿠폰_삭제_불가() {
+            Coupon coupon = CouponFixture.coupon(10L, otherPartner);
+            given(couponRepository.findByIdFetchPartner(10L)).willReturn(Optional.of(coupon));
+
+            assertThatThrownBy(() -> couponService.deleteCoupon(partnerDetails, 10L))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_EXCEPTION));
+            verify(couponRepository, never()).delete(coupon);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 쿠폰이면 ENTITY_NOT_FOUND 예외가 발생한다")
+        void 쿠폰_없음() {
+            given(couponRepository.findByIdFetchPartner(anyLong())).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> couponService.deleteCoupon(partnerDetails, 99L))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ENTITY_NOT_FOUND));
+        }
+    }
+
+    @Nested
+    @DisplayName("updateCoupon")
+    class UpdateCoupon {
+
+        @Test
+        @DisplayName("자기 파트너의 쿠폰 정보를 수정한다")
+        void 본인_쿠폰_수정() {
+            Coupon coupon = CouponFixture.coupon(10L, myPartner);
+            given(couponRepository.findByIdFetchPartner(10L)).willReturn(Optional.of(coupon));
+            CouponUpdateRequest request = new CouponUpdateRequest(
+                "수정된 제목", null, null, null, null, null, null, null);
+
+            CouponCreateResponse response =
+                couponService.updateCoupon(partnerDetails, 10L, request);
+
+            assertThat(coupon.getTitle()).isEqualTo("수정된 제목");
+            assertThat(response.title()).isEqualTo("수정된 제목");
+            assertThat(response.couponId()).isEqualTo(10L);
+        }
+
+        @Test
+        @DisplayName("다른 파트너의 쿠폰을 수정하면 ACCESS_DENIED 예외가 발생하고 값이 유지된다")
+        void 다른_파트너_쿠폰_수정_불가() {
+            Coupon coupon = CouponFixture.coupon(10L, otherPartner);
+            given(couponRepository.findByIdFetchPartner(10L)).willReturn(Optional.of(coupon));
+            CouponUpdateRequest request = new CouponUpdateRequest(
+                "수정된 제목", null, null, null, null, null, null, null);
+
+            assertThatThrownBy(() -> couponService.updateCoupon(partnerDetails, 10L, request))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_EXCEPTION));
+            assertThat(coupon.getTitle()).isEqualTo("어스어스 3000원 할인 쿠폰");
+        }
+    }
+
+    @Nested
+    @DisplayName("useCoupon")
+    class UseCoupon {
+
+        @Test
+        @DisplayName("보유 쿠폰을 사용 완료 상태로 전이시킨다")
+        void 쿠폰_사용() {
+            Coupon coupon = CouponFixture.coupon(10L, myPartner);
+            UserCoupon userCoupon = UserCoupon.create(UserFixture.user(5L), coupon);
+            given(userCouponRepository.findById(100L)).willReturn(Optional.of(userCoupon));
+
+            couponService.useCoupon(partnerDetails, 100L);
+
+            assertThat(userCoupon.getStatus()).isEqualTo(CouponStatus.USED);
+            assertThat(userCoupon.getUsedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 보유 쿠폰이면 ENTITY_NOT_FOUND 예외가 발생한다")
+        void 보유_쿠폰_없음() {
+            given(userCouponRepository.findById(anyLong())).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> couponService.useCoupon(partnerDetails, 99L))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ENTITY_NOT_FOUND));
+        }
+
+        @Test
+        @Disabled("버그 재현: useCoupon은 쿠폰이 요청 파트너 소속인지 검증하지 않아 다른 파트너의 쿠폰도 사용 처리된다. 소유권 검증 추가(fix) 후 활성화 예정")
+        @DisplayName("다른 파트너 소속 쿠폰을 사용하면 ACCESS_DENIED 예외가 발생해야 한다")
+        void 다른_파트너_쿠폰_사용_불가() {
+            Coupon coupon = CouponFixture.coupon(10L, otherPartner);
+            UserCoupon userCoupon = UserCoupon.create(UserFixture.user(5L), coupon);
+            given(userCouponRepository.findById(100L)).willReturn(Optional.of(userCoupon));
+
+            assertThatThrownBy(() -> couponService.useCoupon(partnerDetails, 100L))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED_EXCEPTION));
+            assertThat(userCoupon.getStatus()).isEqualTo(CouponStatus.AVAILABLE);
+        }
+    }
+}

--- a/src/test/java/com/trashheroesbe/feature/coupon/application/CouponServiceTest.java
+++ b/src/test/java/com/trashheroesbe/feature/coupon/application/CouponServiceTest.java
@@ -24,7 +24,6 @@ import com.trashheroesbe.global.exception.BusinessException;
 import com.trashheroesbe.global.response.type.ErrorCode;
 import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -217,8 +216,7 @@ class CouponServiceTest {
         }
 
         @Test
-        @Disabled("버그 재현: useCoupon은 쿠폰이 요청 파트너 소속인지 검증하지 않아 다른 파트너의 쿠폰도 사용 처리된다. 소유권 검증 추가(fix) 후 활성화 예정")
-        @DisplayName("다른 파트너 소속 쿠폰을 사용하면 ACCESS_DENIED 예외가 발생해야 한다")
+        @DisplayName("다른 파트너 소속 쿠폰을 사용하면 ACCESS_DENIED 예외가 발생한다")
         void 다른_파트너_쿠폰_사용_불가() {
             // given
             Coupon coupon = CouponFixture.coupon(10L, otherPartner);

--- a/src/test/java/com/trashheroesbe/feature/coupon/application/CouponStoreServiceTest.java
+++ b/src/test/java/com/trashheroesbe/feature/coupon/application/CouponStoreServiceTest.java
@@ -1,0 +1,179 @@
+package com.trashheroesbe.feature.coupon.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.trashheroesbe.feature.coupon.domain.entity.Coupon;
+import com.trashheroesbe.feature.coupon.domain.entity.UserCoupon;
+import com.trashheroesbe.feature.coupon.domain.type.CouponStatus;
+import com.trashheroesbe.feature.coupon.dto.request.CouponPurchaseRequest;
+import com.trashheroesbe.feature.coupon.dto.response.PurchaseUserCouponResponse;
+import com.trashheroesbe.feature.coupon.infrastructure.CouponRepository;
+import com.trashheroesbe.feature.coupon.infrastructure.UserCouponRepository;
+import com.trashheroesbe.feature.partner.domain.entity.Partner;
+import com.trashheroesbe.feature.point.application.PointService;
+import com.trashheroesbe.feature.point.domain.type.PointReason;
+import com.trashheroesbe.feature.user.domain.entity.User;
+import com.trashheroesbe.fixture.CouponFixture;
+import com.trashheroesbe.fixture.PartnerFixture;
+import com.trashheroesbe.fixture.UserFixture;
+import com.trashheroesbe.global.exception.BusinessException;
+import com.trashheroesbe.global.qrcode.QrCodeGenerator;
+import com.trashheroesbe.global.response.type.ErrorCode;
+import com.trashheroesbe.infrastructure.port.s3.FileStoragePort;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class CouponStoreServiceTest {
+
+    private static final String QR_BASE_URL = "https://test.trash-heroes.store/api/v1/my/coupons/qr";
+
+    @Mock
+    private PointService pointService;
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @Mock
+    private UserCouponRepository userCouponRepository;
+
+    @Mock
+    private QrCodeGenerator qrCodeGenerator;
+
+    @Mock
+    private FileStoragePort fileStoragePort;
+
+    @InjectMocks
+    private CouponStoreService couponStoreService;
+
+    private final Partner partner = PartnerFixture.partner(1L);
+    private final User user = UserFixture.user(5L);
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(couponStoreService, "userCouponQrBaseUrl", QR_BASE_URL);
+    }
+
+    @Test
+    @DisplayName("구매 성공 시 재고 차감, 포인트 사용, QR 발급까지 수행한다")
+    void 구매_성공() {
+        Coupon coupon = CouponFixture.builder(10L, partner)
+            .totalStock(10)
+            .issuedCount(3)
+            .pointCost(3000)
+            .build();
+        given(couponRepository.findByIdFetchPartner(10L)).willReturn(Optional.of(coupon));
+
+        UserCoupon savedUserCoupon = UserCoupon.builder()
+            .id(100L)
+            .user(user)
+            .coupon(coupon)
+            .status(CouponStatus.AVAILABLE)
+            .build();
+        given(userCouponRepository.save(any(UserCoupon.class))).willReturn(savedUserCoupon);
+        given(qrCodeGenerator.generatePngBytes(anyString(), eq(300)))
+            .willReturn(new byte[]{1, 2, 3});
+        given(fileStoragePort.uploadFile(eq("user-coupon/100/qr.png"), eq("image/png"), any()))
+            .willReturn("https://storage.test/user-coupon/100/qr.png");
+
+        PurchaseUserCouponResponse response =
+            couponStoreService.purchaseCoupon(new CouponPurchaseRequest(10L), user);
+
+        assertThat(coupon.getIssuedCount()).isEqualTo(4);
+        verify(pointService).usePoint(user.getId(), 3000, PointReason.COUPON_PURCHASE, 10L);
+
+        ArgumentCaptor<String> payloadCaptor = ArgumentCaptor.forClass(String.class);
+        verify(qrCodeGenerator).generatePngBytes(payloadCaptor.capture(), eq(300));
+        assertThat(payloadCaptor.getValue())
+            .startsWith(QR_BASE_URL + "?userCouponId=100&qrToken=");
+
+        assertThat(savedUserCoupon.getQrToken()).isNotBlank();
+        assertThat(savedUserCoupon.getQrImageUrl())
+            .isEqualTo("https://storage.test/user-coupon/100/qr.png");
+
+        assertThat(response.userCouponId()).isEqualTo(100L);
+        assertThat(response.couponId()).isEqualTo(10L);
+        assertThat(response.pointsUsed()).isEqualTo(3000);
+        assertThat(response.qrImageUrl())
+            .isEqualTo("https://storage.test/user-coupon/100/qr.png");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 쿠폰이면 COUPON_NOT_FOUND 예외가 발생한다")
+    void 쿠폰_없음() {
+        given(couponRepository.findByIdFetchPartner(anyLong())).willReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+            couponStoreService.purchaseCoupon(new CouponPurchaseRequest(99L), user))
+            .isInstanceOfSatisfying(BusinessException.class, e ->
+                assertThat(e.getErrorCode()).isEqualTo(ErrorCode.COUPON_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("비활성 쿠폰이면 COUPON_NOT_AVAILABLE 예외가 발생하고 포인트는 차감되지 않는다")
+    void 비활성_쿠폰() {
+        Coupon coupon = CouponFixture.builder(10L, partner)
+            .isActive(false)
+            .build();
+        given(couponRepository.findByIdFetchPartner(10L)).willReturn(Optional.of(coupon));
+
+        assertThatThrownBy(() ->
+            couponStoreService.purchaseCoupon(new CouponPurchaseRequest(10L), user))
+            .isInstanceOfSatisfying(BusinessException.class, e ->
+                assertThat(e.getErrorCode()).isEqualTo(ErrorCode.COUPON_NOT_AVAILABLE));
+        assertThat(coupon.getIssuedCount()).isZero();
+        verify(pointService, never()).usePoint(anyLong(), anyInt(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("재고가 소진된 쿠폰이면 COUPON_OUT_OF_STOCK 예외가 발생하고 포인트는 차감되지 않는다")
+    void 재고_소진() {
+        Coupon coupon = CouponFixture.builder(10L, partner)
+            .totalStock(5)
+            .issuedCount(5)
+            .build();
+        given(couponRepository.findByIdFetchPartner(10L)).willReturn(Optional.of(coupon));
+
+        assertThatThrownBy(() ->
+            couponStoreService.purchaseCoupon(new CouponPurchaseRequest(10L), user))
+            .isInstanceOfSatisfying(BusinessException.class, e ->
+                assertThat(e.getErrorCode()).isEqualTo(ErrorCode.COUPON_OUT_OF_STOCK));
+        verify(pointService, never()).usePoint(anyLong(), anyInt(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("포인트가 부족하면 예외가 전파되고 보유 쿠폰은 저장되지 않는다")
+    void 포인트_부족() {
+        Coupon coupon = CouponFixture.builder(10L, partner)
+            .pointCost(3000)
+            .build();
+        given(couponRepository.findByIdFetchPartner(10L)).willReturn(Optional.of(coupon));
+        willThrow(new BusinessException(ErrorCode.INSUFFICIENT_POINTS))
+            .given(pointService)
+            .usePoint(user.getId(), 3000, PointReason.COUPON_PURCHASE, 10L);
+
+        assertThatThrownBy(() ->
+            couponStoreService.purchaseCoupon(new CouponPurchaseRequest(10L), user))
+            .isInstanceOfSatisfying(BusinessException.class, e ->
+                assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INSUFFICIENT_POINTS));
+        verify(userCouponRepository, never()).save(any(UserCoupon.class));
+    }
+}

--- a/src/test/java/com/trashheroesbe/feature/coupon/application/CouponStoreServiceTest.java
+++ b/src/test/java/com/trashheroesbe/feature/coupon/application/CouponStoreServiceTest.java
@@ -75,6 +75,7 @@ class CouponStoreServiceTest {
     @Test
     @DisplayName("구매 성공 시 재고 차감, 포인트 사용, QR 발급까지 수행한다")
     void 구매_성공() {
+        // given
         Coupon coupon = CouponFixture.builder(10L, partner)
             .totalStock(10)
             .issuedCount(3)
@@ -94,9 +95,11 @@ class CouponStoreServiceTest {
         given(fileStoragePort.uploadFile(eq("user-coupon/100/qr.png"), eq("image/png"), any()))
             .willReturn("https://storage.test/user-coupon/100/qr.png");
 
+        // when
         PurchaseUserCouponResponse response =
             couponStoreService.purchaseCoupon(new CouponPurchaseRequest(10L), user);
 
+        // then
         assertThat(coupon.getIssuedCount()).isEqualTo(4);
         verify(pointService).usePoint(user.getId(), 3000, PointReason.COUPON_PURCHASE, 10L);
 
@@ -119,8 +122,10 @@ class CouponStoreServiceTest {
     @Test
     @DisplayName("존재하지 않는 쿠폰이면 COUPON_NOT_FOUND 예외가 발생한다")
     void 쿠폰_없음() {
+        // given
         given(couponRepository.findByIdFetchPartner(anyLong())).willReturn(Optional.empty());
 
+        // when & then
         assertThatThrownBy(() ->
             couponStoreService.purchaseCoupon(new CouponPurchaseRequest(99L), user))
             .isInstanceOfSatisfying(BusinessException.class, e ->
@@ -130,11 +135,13 @@ class CouponStoreServiceTest {
     @Test
     @DisplayName("비활성 쿠폰이면 COUPON_NOT_AVAILABLE 예외가 발생하고 포인트는 차감되지 않는다")
     void 비활성_쿠폰() {
+        // given
         Coupon coupon = CouponFixture.builder(10L, partner)
             .isActive(false)
             .build();
         given(couponRepository.findByIdFetchPartner(10L)).willReturn(Optional.of(coupon));
 
+        // when & then
         assertThatThrownBy(() ->
             couponStoreService.purchaseCoupon(new CouponPurchaseRequest(10L), user))
             .isInstanceOfSatisfying(BusinessException.class, e ->
@@ -146,12 +153,14 @@ class CouponStoreServiceTest {
     @Test
     @DisplayName("재고가 소진된 쿠폰이면 COUPON_OUT_OF_STOCK 예외가 발생하고 포인트는 차감되지 않는다")
     void 재고_소진() {
+        // given
         Coupon coupon = CouponFixture.builder(10L, partner)
             .totalStock(5)
             .issuedCount(5)
             .build();
         given(couponRepository.findByIdFetchPartner(10L)).willReturn(Optional.of(coupon));
 
+        // when & then
         assertThatThrownBy(() ->
             couponStoreService.purchaseCoupon(new CouponPurchaseRequest(10L), user))
             .isInstanceOfSatisfying(BusinessException.class, e ->
@@ -162,6 +171,7 @@ class CouponStoreServiceTest {
     @Test
     @DisplayName("포인트가 부족하면 예외가 전파되고 보유 쿠폰은 저장되지 않는다")
     void 포인트_부족() {
+        // given
         Coupon coupon = CouponFixture.builder(10L, partner)
             .pointCost(3000)
             .build();
@@ -170,6 +180,7 @@ class CouponStoreServiceTest {
             .given(pointService)
             .usePoint(user.getId(), 3000, PointReason.COUPON_PURCHASE, 10L);
 
+        // when & then
         assertThatThrownBy(() ->
             couponStoreService.purchaseCoupon(new CouponPurchaseRequest(10L), user))
             .isInstanceOfSatisfying(BusinessException.class, e ->

--- a/src/test/java/com/trashheroesbe/feature/coupon/domain/entity/CouponTest.java
+++ b/src/test/java/com/trashheroesbe/feature/coupon/domain/entity/CouponTest.java
@@ -1,0 +1,171 @@
+package com.trashheroesbe.feature.coupon.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.trashheroesbe.feature.coupon.domain.type.CouponType;
+import com.trashheroesbe.feature.coupon.domain.type.DiscountType;
+import com.trashheroesbe.feature.coupon.dto.request.CouponCreateRequest;
+import com.trashheroesbe.feature.partner.domain.entity.Partner;
+import com.trashheroesbe.fixture.CouponFixture;
+import com.trashheroesbe.fixture.PartnerFixture;
+import com.trashheroesbe.global.exception.BusinessException;
+import com.trashheroesbe.global.response.type.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class CouponTest {
+
+    private final Partner partner = PartnerFixture.partner(1L);
+
+    @Nested
+    @DisplayName("create")
+    class Create {
+
+        @Test
+        @DisplayName("생성 시 발급 수량 0, 활성 상태로 초기화된다")
+        void 생성_초기값() {
+            CouponCreateRequest request = new CouponCreateRequest(
+                "어스어스 3000원 할인 쿠폰",
+                "어스어스에서 3000원 할인받을 수 있는 쿠폰",
+                CouponType.OFFLINE,
+                3000,
+                DiscountType.AMOUNT,
+                3000,
+                100
+            );
+
+            Coupon coupon = Coupon.create(request, partner);
+
+            assertThat(coupon.getIssuedCount()).isZero();
+            assertThat(coupon.getIsActive()).isTrue();
+            assertThat(coupon.getPartner()).isSameAs(partner);
+            assertThat(coupon.getTitle()).isEqualTo(request.title());
+            assertThat(coupon.getContent()).isEqualTo(request.content());
+            assertThat(coupon.getType()).isEqualTo(request.type());
+            assertThat(coupon.getPointCost()).isEqualTo(request.pointCost());
+            assertThat(coupon.getDiscountType()).isEqualTo(request.discountType());
+            assertThat(coupon.getDiscountValue()).isEqualTo(request.discountValue());
+            assertThat(coupon.getTotalStock()).isEqualTo(request.totalStock());
+        }
+    }
+
+    @Nested
+    @DisplayName("issue")
+    class Issue {
+
+        @Test
+        @DisplayName("발급하면 발급 수량이 1 증가한다")
+        void 발급_수량_증가() {
+            Coupon coupon = CouponFixture.builder(1L, partner)
+                .totalStock(10)
+                .issuedCount(3)
+                .build();
+
+            coupon.issue();
+
+            assertThat(coupon.getIssuedCount()).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("마지막 남은 한 장까지 발급할 수 있다")
+        void 마지막_한장_발급() {
+            Coupon coupon = CouponFixture.builder(1L, partner)
+                .totalStock(1)
+                .issuedCount(0)
+                .build();
+
+            coupon.issue();
+
+            assertThat(coupon.getIssuedCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("재고가 모두 소진되면 COUPON_OUT_OF_STOCK 예외가 발생하고 수량은 변하지 않는다")
+        void 재고_소진_예외() {
+            Coupon coupon = CouponFixture.builder(1L, partner)
+                .totalStock(5)
+                .issuedCount(5)
+                .build();
+
+            assertThatThrownBy(coupon::issue)
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.COUPON_OUT_OF_STOCK));
+            assertThat(coupon.getIssuedCount()).isEqualTo(5);
+        }
+    }
+
+    @Nested
+    @DisplayName("applyUpdate")
+    class ApplyUpdate {
+
+        @Test
+        @DisplayName("null 필드는 기존 값을 유지한다")
+        void null_필드_유지() {
+            Coupon coupon = CouponFixture.coupon(1L, partner);
+
+            coupon.applyUpdate(null, null, null, null, null, null, null, null);
+
+            assertThat(coupon.getTitle()).isEqualTo("어스어스 3000원 할인 쿠폰");
+            assertThat(coupon.getContent()).isEqualTo("어스어스에서 3000원 할인받을 수 있는 쿠폰");
+            assertThat(coupon.getType()).isEqualTo(CouponType.OFFLINE);
+            assertThat(coupon.getPointCost()).isEqualTo(3000);
+            assertThat(coupon.getDiscountType()).isEqualTo(DiscountType.AMOUNT);
+            assertThat(coupon.getDiscountValue()).isEqualTo(3000);
+            assertThat(coupon.getTotalStock()).isEqualTo(10);
+            assertThat(coupon.getIsActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("빈 문자열 제목과 내용은 무시된다")
+        void 빈_문자열_무시() {
+            Coupon coupon = CouponFixture.coupon(1L, partner);
+
+            coupon.applyUpdate("  ", "  ", null, null, null, null, null, null);
+
+            assertThat(coupon.getTitle()).isEqualTo("어스어스 3000원 할인 쿠폰");
+            assertThat(coupon.getContent()).isEqualTo("어스어스에서 3000원 할인받을 수 있는 쿠폰");
+        }
+
+        @Test
+        @DisplayName("값이 있는 필드만 반영된다")
+        void 부분_수정() {
+            Coupon coupon = CouponFixture.coupon(1L, partner);
+
+            coupon.applyUpdate("새 제목", null, null, 500, null, null, null, false);
+
+            assertThat(coupon.getTitle()).isEqualTo("새 제목");
+            assertThat(coupon.getPointCost()).isEqualTo(500);
+            assertThat(coupon.getIsActive()).isFalse();
+            assertThat(coupon.getContent()).isEqualTo("어스어스에서 3000원 할인받을 수 있는 쿠폰");
+        }
+
+        @Test
+        @DisplayName("재고를 이미 발급된 수량보다 작게 줄이면 예외가 발생한다")
+        void 재고_축소_불가() {
+            Coupon coupon = CouponFixture.builder(1L, partner)
+                .totalStock(10)
+                .issuedCount(5)
+                .build();
+
+            assertThatThrownBy(() ->
+                coupon.applyUpdate(null, null, null, null, null, null, 3, null))
+                .isInstanceOf(IllegalArgumentException.class);
+            assertThat(coupon.getTotalStock()).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("재고를 발급된 수량과 같게 줄이는 것은 허용된다")
+        void 재고_동일_축소_허용() {
+            Coupon coupon = CouponFixture.builder(1L, partner)
+                .totalStock(10)
+                .issuedCount(5)
+                .build();
+
+            coupon.applyUpdate(null, null, null, null, null, null, 5, null);
+
+            assertThat(coupon.getTotalStock()).isEqualTo(5);
+        }
+    }
+}

--- a/src/test/java/com/trashheroesbe/feature/coupon/domain/entity/CouponTest.java
+++ b/src/test/java/com/trashheroesbe/feature/coupon/domain/entity/CouponTest.java
@@ -26,6 +26,7 @@ class CouponTest {
         @Test
         @DisplayName("생성 시 발급 수량 0, 활성 상태로 초기화된다")
         void 생성_초기값() {
+            // given
             CouponCreateRequest request = new CouponCreateRequest(
                 "어스어스 3000원 할인 쿠폰",
                 "어스어스에서 3000원 할인받을 수 있는 쿠폰",
@@ -36,8 +37,10 @@ class CouponTest {
                 100
             );
 
+            // when
             Coupon coupon = Coupon.create(request, partner);
 
+            // then
             assertThat(coupon.getIssuedCount()).isZero();
             assertThat(coupon.getIsActive()).isTrue();
             assertThat(coupon.getPartner()).isSameAs(partner);
@@ -58,37 +61,45 @@ class CouponTest {
         @Test
         @DisplayName("발급하면 발급 수량이 1 증가한다")
         void 발급_수량_증가() {
+            // given
             Coupon coupon = CouponFixture.builder(1L, partner)
                 .totalStock(10)
                 .issuedCount(3)
                 .build();
 
+            // when
             coupon.issue();
 
+            // then
             assertThat(coupon.getIssuedCount()).isEqualTo(4);
         }
 
         @Test
         @DisplayName("마지막 남은 한 장까지 발급할 수 있다")
         void 마지막_한장_발급() {
+            // given
             Coupon coupon = CouponFixture.builder(1L, partner)
                 .totalStock(1)
                 .issuedCount(0)
                 .build();
 
+            // when
             coupon.issue();
 
+            // then
             assertThat(coupon.getIssuedCount()).isEqualTo(1);
         }
 
         @Test
         @DisplayName("재고가 모두 소진되면 COUPON_OUT_OF_STOCK 예외가 발생하고 수량은 변하지 않는다")
         void 재고_소진_예외() {
+            // given
             Coupon coupon = CouponFixture.builder(1L, partner)
                 .totalStock(5)
                 .issuedCount(5)
                 .build();
 
+            // when & then
             assertThatThrownBy(coupon::issue)
                 .isInstanceOfSatisfying(BusinessException.class, e ->
                     assertThat(e.getErrorCode()).isEqualTo(ErrorCode.COUPON_OUT_OF_STOCK));
@@ -103,10 +114,13 @@ class CouponTest {
         @Test
         @DisplayName("null 필드는 기존 값을 유지한다")
         void null_필드_유지() {
+            // given
             Coupon coupon = CouponFixture.coupon(1L, partner);
 
+            // when
             coupon.applyUpdate(null, null, null, null, null, null, null, null);
 
+            // then
             assertThat(coupon.getTitle()).isEqualTo("어스어스 3000원 할인 쿠폰");
             assertThat(coupon.getContent()).isEqualTo("어스어스에서 3000원 할인받을 수 있는 쿠폰");
             assertThat(coupon.getType()).isEqualTo(CouponType.OFFLINE);
@@ -120,10 +134,13 @@ class CouponTest {
         @Test
         @DisplayName("빈 문자열 제목과 내용은 무시된다")
         void 빈_문자열_무시() {
+            // given
             Coupon coupon = CouponFixture.coupon(1L, partner);
 
+            // when
             coupon.applyUpdate("  ", "  ", null, null, null, null, null, null);
 
+            // then
             assertThat(coupon.getTitle()).isEqualTo("어스어스 3000원 할인 쿠폰");
             assertThat(coupon.getContent()).isEqualTo("어스어스에서 3000원 할인받을 수 있는 쿠폰");
         }
@@ -131,10 +148,13 @@ class CouponTest {
         @Test
         @DisplayName("값이 있는 필드만 반영된다")
         void 부분_수정() {
+            // given
             Coupon coupon = CouponFixture.coupon(1L, partner);
 
+            // when
             coupon.applyUpdate("새 제목", null, null, 500, null, null, null, false);
 
+            // then
             assertThat(coupon.getTitle()).isEqualTo("새 제목");
             assertThat(coupon.getPointCost()).isEqualTo(500);
             assertThat(coupon.getIsActive()).isFalse();
@@ -144,11 +164,13 @@ class CouponTest {
         @Test
         @DisplayName("재고를 이미 발급된 수량보다 작게 줄이면 예외가 발생한다")
         void 재고_축소_불가() {
+            // given
             Coupon coupon = CouponFixture.builder(1L, partner)
                 .totalStock(10)
                 .issuedCount(5)
                 .build();
 
+            // when & then
             assertThatThrownBy(() ->
                 coupon.applyUpdate(null, null, null, null, null, null, 3, null))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -158,13 +180,16 @@ class CouponTest {
         @Test
         @DisplayName("재고를 발급된 수량과 같게 줄이는 것은 허용된다")
         void 재고_동일_축소_허용() {
+            // given
             Coupon coupon = CouponFixture.builder(1L, partner)
                 .totalStock(10)
                 .issuedCount(5)
                 .build();
 
+            // when
             coupon.applyUpdate(null, null, null, null, null, null, 5, null);
 
+            // then
             assertThat(coupon.getTotalStock()).isEqualTo(5);
         }
     }

--- a/src/test/java/com/trashheroesbe/feature/coupon/domain/entity/UserCouponTest.java
+++ b/src/test/java/com/trashheroesbe/feature/coupon/domain/entity/UserCouponTest.java
@@ -1,0 +1,99 @@
+package com.trashheroesbe.feature.coupon.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.trashheroesbe.feature.coupon.domain.type.CouponStatus;
+import com.trashheroesbe.feature.partner.domain.entity.Partner;
+import com.trashheroesbe.feature.user.domain.entity.User;
+import com.trashheroesbe.fixture.CouponFixture;
+import com.trashheroesbe.fixture.PartnerFixture;
+import com.trashheroesbe.fixture.UserFixture;
+import com.trashheroesbe.global.exception.BusinessException;
+import com.trashheroesbe.global.response.type.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class UserCouponTest {
+
+    private final Partner partner = PartnerFixture.partner(1L);
+    private final User user = UserFixture.user(1L);
+    private final Coupon coupon = CouponFixture.coupon(1L, partner);
+
+    @Nested
+    @DisplayName("create")
+    class Create {
+
+        @Test
+        @DisplayName("생성 시 사용 가능 상태로 초기화된다")
+        void 생성_초기값() {
+            UserCoupon userCoupon = UserCoupon.create(user, coupon);
+
+            assertThat(userCoupon.getStatus()).isEqualTo(CouponStatus.AVAILABLE);
+            assertThat(userCoupon.getUsedAt()).isNull();
+            assertThat(userCoupon.getUser()).isSameAs(user);
+            assertThat(userCoupon.getCoupon()).isSameAs(coupon);
+        }
+    }
+
+    @Nested
+    @DisplayName("useCoupon")
+    class UseCoupon {
+
+        @Test
+        @DisplayName("사용하면 사용 완료 상태가 되고 사용 시각이 기록된다")
+        void 사용_상태_전이() {
+            UserCoupon userCoupon = UserCoupon.create(user, coupon);
+
+            userCoupon.useCoupon();
+
+            assertThat(userCoupon.getStatus()).isEqualTo(CouponStatus.USED);
+            assertThat(userCoupon.getUsedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("attachQr")
+    class AttachQr {
+
+        @Test
+        @DisplayName("QR 토큰과 이미지 URL을 저장한다")
+        void QR_저장() {
+            UserCoupon userCoupon = UserCoupon.create(user, coupon);
+
+            userCoupon.attachQr("qr-token", "https://storage.test/qr.png");
+
+            assertThat(userCoupon.getQrToken()).isEqualTo("qr-token");
+            assertThat(userCoupon.getQrImageUrl()).isEqualTo("https://storage.test/qr.png");
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {"", "  "})
+        @DisplayName("QR 토큰이 비어 있으면 VALIDATION_FAILED 예외가 발생한다")
+        void 토큰_검증(String invalidToken) {
+            UserCoupon userCoupon = UserCoupon.create(user, coupon);
+
+            assertThatThrownBy(() ->
+                userCoupon.attachQr(invalidToken, "https://storage.test/qr.png"))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.VALIDATION_FAILED));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {"", "  "})
+        @DisplayName("QR 이미지 URL이 비어 있으면 VALIDATION_FAILED 예외가 발생한다")
+        void URL_검증(String invalidUrl) {
+            UserCoupon userCoupon = UserCoupon.create(user, coupon);
+
+            assertThatThrownBy(() -> userCoupon.attachQr("qr-token", invalidUrl))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.VALIDATION_FAILED));
+        }
+    }
+}

--- a/src/test/java/com/trashheroesbe/feature/coupon/domain/entity/UserCouponTest.java
+++ b/src/test/java/com/trashheroesbe/feature/coupon/domain/entity/UserCouponTest.java
@@ -31,8 +31,10 @@ class UserCouponTest {
         @Test
         @DisplayName("생성 시 사용 가능 상태로 초기화된다")
         void 생성_초기값() {
+            // when
             UserCoupon userCoupon = UserCoupon.create(user, coupon);
 
+            // then
             assertThat(userCoupon.getStatus()).isEqualTo(CouponStatus.AVAILABLE);
             assertThat(userCoupon.getUsedAt()).isNull();
             assertThat(userCoupon.getUser()).isSameAs(user);
@@ -47,10 +49,13 @@ class UserCouponTest {
         @Test
         @DisplayName("사용하면 사용 완료 상태가 되고 사용 시각이 기록된다")
         void 사용_상태_전이() {
+            // given
             UserCoupon userCoupon = UserCoupon.create(user, coupon);
 
+            // when
             userCoupon.useCoupon();
 
+            // then
             assertThat(userCoupon.getStatus()).isEqualTo(CouponStatus.USED);
             assertThat(userCoupon.getUsedAt()).isNotNull();
         }
@@ -63,10 +68,13 @@ class UserCouponTest {
         @Test
         @DisplayName("QR 토큰과 이미지 URL을 저장한다")
         void QR_저장() {
+            // given
             UserCoupon userCoupon = UserCoupon.create(user, coupon);
 
+            // when
             userCoupon.attachQr("qr-token", "https://storage.test/qr.png");
 
+            // then
             assertThat(userCoupon.getQrToken()).isEqualTo("qr-token");
             assertThat(userCoupon.getQrImageUrl()).isEqualTo("https://storage.test/qr.png");
         }
@@ -76,8 +84,10 @@ class UserCouponTest {
         @ValueSource(strings = {"", "  "})
         @DisplayName("QR 토큰이 비어 있으면 VALIDATION_FAILED 예외가 발생한다")
         void 토큰_검증(String invalidToken) {
+            // given
             UserCoupon userCoupon = UserCoupon.create(user, coupon);
 
+            // when & then
             assertThatThrownBy(() ->
                 userCoupon.attachQr(invalidToken, "https://storage.test/qr.png"))
                 .isInstanceOfSatisfying(BusinessException.class, e ->
@@ -89,8 +99,10 @@ class UserCouponTest {
         @ValueSource(strings = {"", "  "})
         @DisplayName("QR 이미지 URL이 비어 있으면 VALIDATION_FAILED 예외가 발생한다")
         void URL_검증(String invalidUrl) {
+            // given
             UserCoupon userCoupon = UserCoupon.create(user, coupon);
 
+            // when & then
             assertThatThrownBy(() -> userCoupon.attachQr("qr-token", invalidUrl))
                 .isInstanceOfSatisfying(BusinessException.class, e ->
                     assertThat(e.getErrorCode()).isEqualTo(ErrorCode.VALIDATION_FAILED));

--- a/src/test/java/com/trashheroesbe/feature/trash/application/TrashServiceTest.java
+++ b/src/test/java/com/trashheroesbe/feature/trash/application/TrashServiceTest.java
@@ -5,8 +5,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -21,6 +23,9 @@ import com.trashheroesbe.feature.trash.domain.entity.TrashItem;
 import com.trashheroesbe.feature.trash.domain.entity.TrashType;
 import com.trashheroesbe.feature.trash.domain.type.ItemType;
 import com.trashheroesbe.feature.trash.domain.type.Type;
+import com.trashheroesbe.feature.point.dto.response.PointEarnedResult;
+import com.trashheroesbe.feature.trash.domain.entity.TrashPart;
+import com.trashheroesbe.feature.trash.dto.request.CreateTrashRequest;
 import com.trashheroesbe.feature.trash.dto.response.TrashItemResponse;
 import com.trashheroesbe.feature.trash.dto.response.TrashResultResponse;
 import com.trashheroesbe.feature.trash.infrastructure.PartRepository;
@@ -35,17 +40,24 @@ import com.trashheroesbe.fixture.UserFixture;
 import com.trashheroesbe.global.exception.BusinessException;
 import com.trashheroesbe.global.response.type.ErrorCode;
 import com.trashheroesbe.infrastructure.port.gpt.ChatAIClientPort;
+import com.trashheroesbe.infrastructure.port.gpt.ImageAnalysisBundle;
+import com.trashheroesbe.infrastructure.port.gpt.PartSuggestion;
 import com.trashheroesbe.infrastructure.port.s3.FileStoragePort;
+import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 class TrashServiceTest {
@@ -111,6 +123,168 @@ class TrashServiceTest {
             .trashType(type)
             .trashItem(item)
             .build();
+    }
+
+    @Nested
+    @DisplayName("createTrash")
+    class CreateTrash {
+
+        private MockMultipartFile imageFile() {
+            return new MockMultipartFile(
+                "imageFile", "photo.jpg", "image/jpeg", new byte[]{1, 2, 3});
+        }
+
+        @Test
+        @DisplayName("업로드와 AI 분석을 병렬 수행하고 매칭된 품목으로 저장 후 뱃지·포인트를 지급한다")
+        void 생성_성공() {
+            // given
+            TrashType petType = petType();
+            TrashType plasticType = TrashType.builder().id(2L).type(Type.PLASTIC).build();
+            TrashItem petItem = TrashItem.builder()
+                .id(5L).name("PET(투명 페트병)").itemType(ItemType.NORMAL).trashType(petType)
+                .build();
+            TrashItem etcItem = TrashItem.builder()
+                .id(6L).name("기타 플라스틱").itemType(ItemType.NORMAL).trashType(petType)
+                .build();
+
+            given(chatGPTClientPort.analyzeAll(any(byte[].class), eq("image/jpeg")))
+                .willReturn(new ImageAnalysisBundle(Type.PET, "PET(투명 페트병)", "투명 페트병",
+                    List.of(new PartSuggestion("뚜껑", Type.PLASTIC))));
+            given(fileStoragePort.uploadFile(anyString(), eq("image/jpeg"), any(byte[].class)))
+                .willReturn("https://storage.test/trash/stored.jpg");
+            given(trashItemRepository.findByTrashType_Type(Type.PET))
+                .willReturn(List.of(petItem, etcItem));
+            given(trashTypeRepository.findByType(Type.PET)).willReturn(Optional.of(petType));
+            given(trashItemRepository.findByTrashTypeAndName(petType, "PET(투명 페트병)"))
+                .willReturn(Optional.of(petItem));
+            given(trashRepository.save(any(Trash.class))).willAnswer(inv -> inv.getArgument(0));
+            given(pointService.grantPointsForTrash(eq(1L), any()))
+                .willReturn(new PointEarnedResult(30, LocalDateTime.now()));
+            given(trashTypeRepository.findByType(Type.PLASTIC))
+                .willReturn(Optional.of(plasticType));
+            given(partRepository.findByTrashTypeAndName(plasticType, "뚜껑"))
+                .willReturn(Optional.of(
+                    Part.builder().id(7L).name("뚜껑").trashType(plasticType).build()));
+
+            // when
+            TrashResultResponse response =
+                trashService.createTrash(new CreateTrashRequest(imageFile()), owner);
+
+            // then
+            assertThat(response.name()).isEqualTo("투명 페트병");
+            assertThat(response.typeCode()).isEqualTo(Type.PET.getTypeCode());
+            assertThat(response.point().earnPoints()).isEqualTo(30);
+
+            ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+            verify(fileStoragePort)
+                .uploadFile(keyCaptor.capture(), eq("image/jpeg"), any(byte[].class));
+            assertThat(keyCaptor.getValue()).startsWith("trash/").endsWith(".jpg");
+
+            verify(chatGPTClientPort).analyzeAll(any(byte[].class), eq("image/jpeg"));
+            verify(trashItemRepository).findByTrashTypeAndName(petType, "PET(투명 페트병)");
+            verify(badgeService).onTrashAnalysisCompleted(1L, Type.PET);
+            verify(trashPartRepository).save(any(TrashPart.class));
+        }
+
+        @Test
+        @DisplayName("요약명이 품목 목록과 매칭되지 않으면 기타 품목으로 저장한다")
+        void 기타_품목_폴백() {
+            // given
+            TrashType petType = petType();
+            TrashItem petItem = TrashItem.builder()
+                .id(5L).name("PET(투명 페트병)").itemType(ItemType.NORMAL).trashType(petType)
+                .build();
+            TrashItem etcItem = TrashItem.builder()
+                .id(6L).name("기타 플라스틱").itemType(ItemType.NORMAL).trashType(petType)
+                .build();
+
+            given(chatGPTClientPort.analyzeAll(any(byte[].class), eq("image/jpeg")))
+                .willReturn(new ImageAnalysisBundle(Type.PET, null, "정체불명", List.of()));
+            given(fileStoragePort.uploadFile(anyString(), eq("image/jpeg"), any(byte[].class)))
+                .willReturn("https://storage.test/trash/stored.jpg");
+            given(trashItemRepository.findByTrashType_Type(Type.PET))
+                .willReturn(List.of(petItem, etcItem));
+            given(trashTypeRepository.findByType(Type.PET)).willReturn(Optional.of(petType));
+            given(trashItemRepository.findByTrashTypeAndName(petType, "기타 플라스틱"))
+                .willReturn(Optional.of(etcItem));
+            given(trashRepository.save(any(Trash.class))).willAnswer(inv -> inv.getArgument(0));
+            given(pointService.grantPointsForTrash(eq(1L), any()))
+                .willReturn(new PointEarnedResult(10, LocalDateTime.now()));
+
+            // when
+            TrashResultResponse response =
+                trashService.createTrash(new CreateTrashRequest(imageFile()), owner);
+
+            // then
+            assertThat(response.name()).isEqualTo("정체불명");
+            verify(trashItemRepository).findByTrashTypeAndName(petType, "기타 플라스틱");
+            verify(trashPartRepository, never()).save(any(TrashPart.class));
+        }
+
+        @Test
+        @DisplayName("AI 분석 결과가 없으면 UNKNOWN 타입으로 저장된다")
+        void 분석_실패_UNKNOWN_폴백() {
+            // given
+            TrashType unknownType = TrashType.builder().id(9L).type(Type.UNKNOWN).build();
+            given(chatGPTClientPort.analyzeAll(any(byte[].class), eq("image/jpeg")))
+                .willReturn(null);
+            given(fileStoragePort.uploadFile(anyString(), eq("image/jpeg"), any(byte[].class)))
+                .willReturn("https://storage.test/trash/stored.jpg");
+            given(trashTypeRepository.findByType(Type.UNKNOWN))
+                .willReturn(Optional.of(unknownType));
+            given(trashRepository.save(any(Trash.class))).willAnswer(inv -> inv.getArgument(0));
+            given(pointService.grantPointsForTrash(eq(1L), any()))
+                .willReturn(new PointEarnedResult(10, LocalDateTime.now()));
+
+            // when
+            TrashResultResponse response =
+                trashService.createTrash(new CreateTrashRequest(imageFile()), owner);
+
+            // then
+            assertThat(response.typeCode()).isEqualTo(Type.UNKNOWN.getTypeCode());
+            assertThat(response.name()).isEqualTo(Type.UNKNOWN.getNameKo());
+            verify(badgeService).onTrashAnalysisCompleted(1L, Type.UNKNOWN);
+            verify(trashPartRepository, never()).save(any(TrashPart.class));
+        }
+
+        @Test
+        @DisplayName("DB 저장에 실패하면 업로드된 S3 파일을 보상 삭제하고 예외를 전파한다")
+        void DB_실패시_보상_삭제() {
+            // given
+            given(chatGPTClientPort.analyzeAll(any(byte[].class), eq("image/jpeg")))
+                .willReturn(null);
+            given(fileStoragePort.uploadFile(anyString(), eq("image/jpeg"), any(byte[].class)))
+                .willReturn("https://storage.test/trash/stored.jpg");
+            given(trashTypeRepository.findByType(Type.UNKNOWN))
+                .willThrow(new IllegalStateException("DB 연결 실패"));
+
+            // when & then
+            assertThatThrownBy(() ->
+                trashService.createTrash(new CreateTrashRequest(imageFile()), owner))
+                .isInstanceOf(IllegalStateException.class);
+            verify(fileStoragePort).deleteFileByUrl("https://storage.test/trash/stored.jpg");
+            verify(trashRepository, never()).save(any(Trash.class));
+        }
+
+        @Test
+        @DisplayName("파일을 읽을 수 없으면 INTERNAL_SERVER_ERROR 예외가 발생하고 외부 호출은 하지 않는다")
+        void 파일_읽기_실패() throws IOException {
+            // given
+            MultipartFile brokenFile = mock(MultipartFile.class);
+            given(brokenFile.isEmpty()).willReturn(false);
+            given(brokenFile.getContentType()).willReturn("image/jpeg");
+            given(brokenFile.getSize()).willReturn(3L);
+            given(brokenFile.getOriginalFilename()).willReturn("photo.jpg");
+            given(brokenFile.getBytes()).willThrow(new IOException("파일 읽기 실패"));
+
+            // when & then
+            assertThatThrownBy(() ->
+                trashService.createTrash(new CreateTrashRequest(brokenFile), owner))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR));
+            verify(fileStoragePort, never()).uploadFile(anyString(), anyString(), any(byte[].class));
+            verify(chatGPTClientPort, never()).analyzeAll(any(byte[].class), anyString());
+        }
     }
 
     @Nested

--- a/src/test/java/com/trashheroesbe/feature/trash/application/TrashServiceTest.java
+++ b/src/test/java/com/trashheroesbe/feature/trash/application/TrashServiceTest.java
@@ -489,10 +489,8 @@ class TrashServiceTest {
         }
 
         @Test
-        @DisplayName("현재 동작 문서화: 리다이렉트 타입이 없는 CAUTION 품목이면 타입이 null이 된다 (가드 조건 버그 의심)")
+        @DisplayName("리다이렉트 타입이 없는 CAUTION 품목이면 기존 타입을 유지한다")
         void 리다이렉트_없는_주의_품목() {
-            // createTrash는 redirectTrashType != null을 검사하지만
-            // changeTrashItem은 item.getTrashType() != null을 검사해 null 타입이 적용된다.
             // given
             TrashType type = petType();
             Trash trash = trashOf(owner, type, null);
@@ -507,8 +505,8 @@ class TrashServiceTest {
             TrashResultResponse response = trashService.changeTrashItem(1L, 5L, owner);
 
             // then
-            assertThat(trash.getTrashType()).isNull();
-            assertThat(response.typeCode()).isNull();
+            assertThat(trash.getTrashType()).isSameAs(type);
+            assertThat(response.typeCode()).isEqualTo(Type.PET.getTypeCode());
         }
     }
 

--- a/src/test/java/com/trashheroesbe/feature/trash/application/TrashServiceTest.java
+++ b/src/test/java/com/trashheroesbe/feature/trash/application/TrashServiceTest.java
@@ -120,8 +120,10 @@ class TrashServiceTest {
         @Test
         @DisplayName("존재하지 않는 쓰레기면 NOT_EXISTS_TRASH_ITEM 예외가 발생한다")
         void 쓰레기_없음() {
+            // given
             given(trashRepository.findById(anyLong())).willReturn(Optional.empty());
 
+            // when & then
             assertThatThrownBy(() -> trashService.getTrash(99L))
                 .isInstanceOfSatisfying(BusinessException.class, e ->
                     assertThat(e.getErrorCode()).isEqualTo(ErrorCode.NOT_EXISTS_TRASH_ITEM));
@@ -130,6 +132,7 @@ class TrashServiceTest {
         @Test
         @DisplayName("타입 정보, 배출 가이드, 부품 카드를 포함한 결과를 반환한다")
         void 상세_조회() {
+            // given
             TrashType type = petType();
             TrashItem item = TrashItem.builder()
                 .id(5L).name("PET(투명 페트병)").itemType(ItemType.NORMAL).trashType(type)
@@ -146,8 +149,10 @@ class TrashServiceTest {
                 Part.builder().id(7L).name("뚜껑").trashType(
                     TrashType.builder().id(2L).type(Type.PLASTIC).build()).build()));
 
+            // when
             TrashResultResponse response = trashService.getTrash(1L);
 
+            // then
             assertThat(response.id()).isEqualTo(1L);
             assertThat(response.itemName()).isEqualTo("PET(투명 페트병)");
             assertThat(response.typeCode()).isEqualTo(Type.PET.getTypeCode());
@@ -168,14 +173,17 @@ class TrashServiceTest {
         @Test
         @DisplayName("사용자의 쓰레기 목록을 응답으로 변환한다")
         void 목록_조회() {
+            // given
             TrashType type = petType();
             Trash first = Trash.builder().id(2L).user(owner).name("페트병").trashType(type).build();
             Trash second = Trash.builder().id(1L).user(owner).name("캔").trashType(type).build();
             given(trashRepository.findByUserOrderByCreatedAtDesc(owner))
                 .willReturn(List.of(first, second));
 
+            // when
             List<TrashResultResponse> responses = trashService.getTrashByUser(owner);
 
+            // then
             assertThat(responses).hasSize(2);
             assertThat(responses.get(0).id()).isEqualTo(2L);
             assertThat(responses.get(1).id()).isEqualTo(1L);
@@ -189,6 +197,7 @@ class TrashServiceTest {
         @Test
         @DisplayName("현재 선택된 품목은 제외하고 CAUTION 품목을 먼저 정렬해 반환한다")
         void 품목_목록_조회() {
+            // given
             TrashType type = petType();
             TrashItem current = TrashItem.builder()
                 .id(5L).name("현재 품목").itemType(ItemType.NORMAL).trashType(type).build();
@@ -201,8 +210,10 @@ class TrashServiceTest {
             given(trashItemRepository.findByTrashTypeId(1L))
                 .willReturn(List.of(current, normal, caution));
 
+            // when
             List<TrashItemResponse> responses = trashService.getTrashItemsByTrashId(1L);
 
+            // then
             assertThat(responses).hasSize(2);
             assertThat(responses.get(0).trashItemId()).isEqualTo(7L);
             assertThat(responses.get(1).trashItemId()).isEqualTo(6L);
@@ -211,10 +222,15 @@ class TrashServiceTest {
         @Test
         @DisplayName("분석된 타입이 없으면 빈 목록을 반환한다")
         void 타입_없음() {
+            // given
             Trash trash = trashOf(owner, null, null);
             given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
 
-            assertThat(trashService.getTrashItemsByTrashId(1L)).isEmpty();
+            // when
+            List<TrashItemResponse> responses = trashService.getTrashItemsByTrashId(1L);
+
+            // then
+            assertThat(responses).isEmpty();
         }
     }
 
@@ -225,9 +241,11 @@ class TrashServiceTest {
         @Test
         @DisplayName("다른 사용자의 쓰레기 품목은 변경할 수 없다")
         void 다른_사용자_변경_불가() {
+            // given
             Trash trash = trashOf(owner, petType(), null);
             given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
 
+            // when & then
             assertThatThrownBy(() -> trashService.changeTrashItem(1L, 5L, otherUser))
                 .isInstanceOfSatisfying(BusinessException.class, e ->
                     assertThat(e.getErrorCode()).isEqualTo(ErrorCode.NOT_EXISTS_TRASH_ITEM));
@@ -237,6 +255,7 @@ class TrashServiceTest {
         @Test
         @DisplayName("쓰레기 타입과 품목 타입이 다르면 변경할 수 없다")
         void 타입_불일치_변경_불가() {
+            // given
             TrashType petType = petType();
             TrashType plasticType = TrashType.builder().id(2L).type(Type.PLASTIC).build();
             Trash trash = trashOf(owner, petType, null);
@@ -246,6 +265,7 @@ class TrashServiceTest {
             given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
             given(trashItemRepository.findById(5L)).willReturn(Optional.of(item));
 
+            // when & then
             assertThatThrownBy(() -> trashService.changeTrashItem(1L, 5L, owner))
                 .isInstanceOfSatisfying(BusinessException.class, e ->
                     assertThat(e.getErrorCode()).isEqualTo(ErrorCode.NOT_EXISTS_TRASH_ITEM));
@@ -254,6 +274,7 @@ class TrashServiceTest {
         @Test
         @DisplayName("같은 타입의 품목으로 변경한다")
         void 품목_변경() {
+            // given
             TrashType type = petType();
             Trash trash = trashOf(owner, type, null);
             TrashItem item = TrashItem.builder()
@@ -262,8 +283,10 @@ class TrashServiceTest {
             given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
             given(trashItemRepository.findById(5L)).willReturn(Optional.of(item));
 
+            // when
             TrashResultResponse response = trashService.changeTrashItem(1L, 5L, owner);
 
+            // then
             assertThat(trash.getTrashItem()).isSameAs(item);
             assertThat(response.itemName()).isEqualTo("PET(투명 페트병)");
             assertThat(response.typeCode()).isEqualTo(Type.PET.getTypeCode());
@@ -272,6 +295,7 @@ class TrashServiceTest {
         @Test
         @DisplayName("CAUTION 품목이면 리다이렉트 타입으로 재분류된다")
         void 주의_품목_재분류() {
+            // given
             TrashType type = petType();
             TrashType redirect = TrashType.builder().id(3L).type(Type.NON_RECYCLABLE).build();
             Trash trash = trashOf(owner, type, null);
@@ -282,8 +306,10 @@ class TrashServiceTest {
             given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
             given(trashItemRepository.findById(5L)).willReturn(Optional.of(item));
 
+            // when
             TrashResultResponse response = trashService.changeTrashItem(1L, 5L, owner);
 
+            // then
             assertThat(trash.getTrashType()).isSameAs(redirect);
             assertThat(response.typeCode()).isEqualTo(Type.NON_RECYCLABLE.getTypeCode());
         }
@@ -293,6 +319,7 @@ class TrashServiceTest {
         void 리다이렉트_없는_주의_품목() {
             // createTrash는 redirectTrashType != null을 검사하지만
             // changeTrashItem은 item.getTrashType() != null을 검사해 null 타입이 적용된다.
+            // given
             TrashType type = petType();
             Trash trash = trashOf(owner, type, null);
             TrashItem item = TrashItem.builder()
@@ -302,8 +329,10 @@ class TrashServiceTest {
             given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
             given(trashItemRepository.findById(5L)).willReturn(Optional.of(item));
 
+            // when
             TrashResultResponse response = trashService.changeTrashItem(1L, 5L, owner);
 
+            // then
             assertThat(trash.getTrashType()).isNull();
             assertThat(response.typeCode()).isNull();
         }
@@ -316,11 +345,14 @@ class TrashServiceTest {
         @Test
         @DisplayName("본인 쓰레기는 S3 이미지와 DB 레코드를 함께 삭제한다")
         void 삭제_성공() {
+            // given
             Trash trash = trashOf(owner, petType(), null);
             given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
 
+            // when
             trashService.deleteTrash(1L, owner);
 
+            // then
             verify(fileStoragePort).deleteFileByUrl("https://storage.test/trash/photo.jpg");
             verify(trashRepository).delete(trash);
         }
@@ -328,9 +360,11 @@ class TrashServiceTest {
         @Test
         @DisplayName("다른 사용자의 쓰레기는 삭제할 수 없다")
         void 다른_사용자_삭제_불가() {
+            // given
             Trash trash = trashOf(owner, petType(), null);
             given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
 
+            // when & then
             assertThatThrownBy(() -> trashService.deleteTrash(1L, otherUser))
                 .isInstanceOfSatisfying(BusinessException.class, e ->
                     assertThat(e.getErrorCode()).isEqualTo(ErrorCode.NOT_EXISTS_TRASH_ITEM));
@@ -341,11 +375,13 @@ class TrashServiceTest {
         @Test
         @DisplayName("S3 삭제가 실패하면 S3_DELETE_FAIL 예외가 발생하고 DB 레코드는 유지된다")
         void S3_삭제_실패() {
+            // given
             Trash trash = trashOf(owner, petType(), null);
             given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
             willThrow(new RuntimeException("connection refused"))
                 .given(fileStoragePort).deleteFileByUrl(anyString());
 
+            // when & then
             assertThatThrownBy(() -> trashService.deleteTrash(1L, owner))
                 .isInstanceOfSatisfying(BusinessException.class, e ->
                     assertThat(e.getErrorCode()).isEqualTo(ErrorCode.S3_DELETE_FAIL));

--- a/src/test/java/com/trashheroesbe/feature/trash/application/TrashServiceTest.java
+++ b/src/test/java/com/trashheroesbe/feature/trash/application/TrashServiceTest.java
@@ -1,0 +1,355 @@
+package com.trashheroesbe.feature.trash.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.trashheroesbe.feature.disposal.infrastructure.DisposalRepository;
+import com.trashheroesbe.feature.badge.application.BadgeService;
+import com.trashheroesbe.feature.point.application.PointService;
+import com.trashheroesbe.feature.search.application.SearchLogService;
+import com.trashheroesbe.feature.trash.domain.entity.Part;
+import com.trashheroesbe.feature.trash.domain.entity.Trash;
+import com.trashheroesbe.feature.trash.domain.entity.TrashDescription;
+import com.trashheroesbe.feature.trash.domain.entity.TrashItem;
+import com.trashheroesbe.feature.trash.domain.entity.TrashType;
+import com.trashheroesbe.feature.trash.domain.type.ItemType;
+import com.trashheroesbe.feature.trash.domain.type.Type;
+import com.trashheroesbe.feature.trash.dto.response.TrashItemResponse;
+import com.trashheroesbe.feature.trash.dto.response.TrashResultResponse;
+import com.trashheroesbe.feature.trash.infrastructure.PartRepository;
+import com.trashheroesbe.feature.trash.infrastructure.TrashDescriptionRepository;
+import com.trashheroesbe.feature.trash.infrastructure.TrashItemRepository;
+import com.trashheroesbe.feature.trash.infrastructure.TrashPartRepository;
+import com.trashheroesbe.feature.trash.infrastructure.TrashRepository;
+import com.trashheroesbe.feature.trash.infrastructure.TrashTypeRepository;
+import com.trashheroesbe.feature.user.domain.entity.User;
+import com.trashheroesbe.feature.user.infrastructure.UserDistrictRepository;
+import com.trashheroesbe.fixture.UserFixture;
+import com.trashheroesbe.global.exception.BusinessException;
+import com.trashheroesbe.global.response.type.ErrorCode;
+import com.trashheroesbe.infrastructure.port.gpt.ChatAIClientPort;
+import com.trashheroesbe.infrastructure.port.s3.FileStoragePort;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ExtendWith(MockitoExtension.class)
+class TrashServiceTest {
+
+    @Mock
+    private TrashRepository trashRepository;
+
+    @Mock
+    private TrashTypeRepository trashTypeRepository;
+
+    @Mock
+    private TrashItemRepository trashItemRepository;
+
+    @Mock
+    private TrashDescriptionRepository trashDescriptionRepository;
+
+    @Mock
+    private DisposalRepository disposalRepository;
+
+    @Mock
+    private UserDistrictRepository userDistrictRepository;
+
+    @Mock
+    private PartRepository partRepository;
+
+    @Mock
+    private TrashPartRepository trashPartRepository;
+
+    @Mock
+    private PlatformTransactionManager txManager;
+
+    @Mock
+    private SearchLogService searchLogService;
+
+    @Mock
+    private BadgeService badgeService;
+
+    @Mock
+    private PointService pointService;
+
+    @Mock
+    private FileStoragePort fileStoragePort;
+
+    @Mock
+    private ChatAIClientPort chatGPTClientPort;
+
+    @InjectMocks
+    private TrashService trashService;
+
+    private final User owner = UserFixture.user(1L);
+    private final User otherUser = UserFixture.user(2L);
+
+    private TrashType petType() {
+        return TrashType.builder().id(1L).type(Type.PET).build();
+    }
+
+    private Trash trashOf(User user, TrashType type, TrashItem item) {
+        return Trash.builder()
+            .id(1L)
+            .user(user)
+            .imageUrl("https://storage.test/trash/photo.jpg")
+            .name("페트병")
+            .trashType(type)
+            .trashItem(item)
+            .build();
+    }
+
+    @Nested
+    @DisplayName("getTrash")
+    class GetTrash {
+
+        @Test
+        @DisplayName("존재하지 않는 쓰레기면 NOT_EXISTS_TRASH_ITEM 예외가 발생한다")
+        void 쓰레기_없음() {
+            given(trashRepository.findById(anyLong())).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> trashService.getTrash(99L))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.NOT_EXISTS_TRASH_ITEM));
+        }
+
+        @Test
+        @DisplayName("타입 정보, 배출 가이드, 부품 카드를 포함한 결과를 반환한다")
+        void 상세_조회() {
+            TrashType type = petType();
+            TrashItem item = TrashItem.builder()
+                .id(5L).name("PET(투명 페트병)").itemType(ItemType.NORMAL).trashType(type)
+                .build();
+            Trash trash = trashOf(owner, type, item);
+            given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
+            given(trashDescriptionRepository.findByTrashType(type)).willReturn(Optional.of(
+                TrashDescription.builder()
+                    .trashType(type)
+                    .methodDetail("STEP 1: 내용물을 비워요.\nSTEP 2: 라벨을 제거해요.")
+                    .cautionNote("주의: 유색 페트병은 분리하지 않아요.")
+                    .build()));
+            given(trashPartRepository.findPartsByTrashId(1L)).willReturn(List.of(
+                Part.builder().id(7L).name("뚜껑").trashType(
+                    TrashType.builder().id(2L).type(Type.PLASTIC).build()).build()));
+
+            TrashResultResponse response = trashService.getTrash(1L);
+
+            assertThat(response.id()).isEqualTo(1L);
+            assertThat(response.itemName()).isEqualTo("PET(투명 페트병)");
+            assertThat(response.typeCode()).isEqualTo(Type.PET.getTypeCode());
+            assertThat(response.typeName()).isEqualTo(Type.PET.getNameKo());
+            assertThat(response.guideSteps()).containsExactly(
+                "STEP 1: 내용물을 비워요.", "STEP 2: 라벨을 제거해요.");
+            assertThat(response.cautionNote()).isEqualTo("주의: 유색 페트병은 분리하지 않아요.");
+            assertThat(response.parts()).hasSize(1);
+            assertThat(response.location()).isNull();
+            assertThat(response.days()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("getTrashByUser")
+    class GetTrashByUser {
+
+        @Test
+        @DisplayName("사용자의 쓰레기 목록을 응답으로 변환한다")
+        void 목록_조회() {
+            TrashType type = petType();
+            Trash first = Trash.builder().id(2L).user(owner).name("페트병").trashType(type).build();
+            Trash second = Trash.builder().id(1L).user(owner).name("캔").trashType(type).build();
+            given(trashRepository.findByUserOrderByCreatedAtDesc(owner))
+                .willReturn(List.of(first, second));
+
+            List<TrashResultResponse> responses = trashService.getTrashByUser(owner);
+
+            assertThat(responses).hasSize(2);
+            assertThat(responses.get(0).id()).isEqualTo(2L);
+            assertThat(responses.get(1).id()).isEqualTo(1L);
+        }
+    }
+
+    @Nested
+    @DisplayName("getTrashItemsByTrashId")
+    class GetTrashItems {
+
+        @Test
+        @DisplayName("현재 선택된 품목은 제외하고 CAUTION 품목을 먼저 정렬해 반환한다")
+        void 품목_목록_조회() {
+            TrashType type = petType();
+            TrashItem current = TrashItem.builder()
+                .id(5L).name("현재 품목").itemType(ItemType.NORMAL).trashType(type).build();
+            TrashItem normal = TrashItem.builder()
+                .id(6L).name("일반 품목").itemType(ItemType.NORMAL).trashType(type).build();
+            TrashItem caution = TrashItem.builder()
+                .id(7L).name("주의 품목").itemType(ItemType.CAUTION).trashType(type).build();
+            Trash trash = trashOf(owner, type, current);
+            given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
+            given(trashItemRepository.findByTrashTypeId(1L))
+                .willReturn(List.of(current, normal, caution));
+
+            List<TrashItemResponse> responses = trashService.getTrashItemsByTrashId(1L);
+
+            assertThat(responses).hasSize(2);
+            assertThat(responses.get(0).trashItemId()).isEqualTo(7L);
+            assertThat(responses.get(1).trashItemId()).isEqualTo(6L);
+        }
+
+        @Test
+        @DisplayName("분석된 타입이 없으면 빈 목록을 반환한다")
+        void 타입_없음() {
+            Trash trash = trashOf(owner, null, null);
+            given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
+
+            assertThat(trashService.getTrashItemsByTrashId(1L)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("changeTrashItem")
+    class ChangeTrashItem {
+
+        @Test
+        @DisplayName("다른 사용자의 쓰레기 품목은 변경할 수 없다")
+        void 다른_사용자_변경_불가() {
+            Trash trash = trashOf(owner, petType(), null);
+            given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
+
+            assertThatThrownBy(() -> trashService.changeTrashItem(1L, 5L, otherUser))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.NOT_EXISTS_TRASH_ITEM));
+            assertThat(trash.getTrashItem()).isNull();
+        }
+
+        @Test
+        @DisplayName("쓰레기 타입과 품목 타입이 다르면 변경할 수 없다")
+        void 타입_불일치_변경_불가() {
+            TrashType petType = petType();
+            TrashType plasticType = TrashType.builder().id(2L).type(Type.PLASTIC).build();
+            Trash trash = trashOf(owner, petType, null);
+            TrashItem item = TrashItem.builder()
+                .id(5L).name("플라스틱 품목").itemType(ItemType.NORMAL).trashType(plasticType)
+                .build();
+            given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
+            given(trashItemRepository.findById(5L)).willReturn(Optional.of(item));
+
+            assertThatThrownBy(() -> trashService.changeTrashItem(1L, 5L, owner))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.NOT_EXISTS_TRASH_ITEM));
+        }
+
+        @Test
+        @DisplayName("같은 타입의 품목으로 변경한다")
+        void 품목_변경() {
+            TrashType type = petType();
+            Trash trash = trashOf(owner, type, null);
+            TrashItem item = TrashItem.builder()
+                .id(5L).name("PET(투명 페트병)").itemType(ItemType.NORMAL).trashType(type)
+                .build();
+            given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
+            given(trashItemRepository.findById(5L)).willReturn(Optional.of(item));
+
+            TrashResultResponse response = trashService.changeTrashItem(1L, 5L, owner);
+
+            assertThat(trash.getTrashItem()).isSameAs(item);
+            assertThat(response.itemName()).isEqualTo("PET(투명 페트병)");
+            assertThat(response.typeCode()).isEqualTo(Type.PET.getTypeCode());
+        }
+
+        @Test
+        @DisplayName("CAUTION 품목이면 리다이렉트 타입으로 재분류된다")
+        void 주의_품목_재분류() {
+            TrashType type = petType();
+            TrashType redirect = TrashType.builder().id(3L).type(Type.NON_RECYCLABLE).build();
+            Trash trash = trashOf(owner, type, null);
+            TrashItem item = TrashItem.builder()
+                .id(5L).name("오염된 페트병").itemType(ItemType.CAUTION)
+                .trashType(type).redirectTrashType(redirect)
+                .build();
+            given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
+            given(trashItemRepository.findById(5L)).willReturn(Optional.of(item));
+
+            TrashResultResponse response = trashService.changeTrashItem(1L, 5L, owner);
+
+            assertThat(trash.getTrashType()).isSameAs(redirect);
+            assertThat(response.typeCode()).isEqualTo(Type.NON_RECYCLABLE.getTypeCode());
+        }
+
+        @Test
+        @DisplayName("현재 동작 문서화: 리다이렉트 타입이 없는 CAUTION 품목이면 타입이 null이 된다 (가드 조건 버그 의심)")
+        void 리다이렉트_없는_주의_품목() {
+            // createTrash는 redirectTrashType != null을 검사하지만
+            // changeTrashItem은 item.getTrashType() != null을 검사해 null 타입이 적용된다.
+            TrashType type = petType();
+            Trash trash = trashOf(owner, type, null);
+            TrashItem item = TrashItem.builder()
+                .id(5L).name("오염된 페트병").itemType(ItemType.CAUTION)
+                .trashType(type).redirectTrashType(null)
+                .build();
+            given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
+            given(trashItemRepository.findById(5L)).willReturn(Optional.of(item));
+
+            TrashResultResponse response = trashService.changeTrashItem(1L, 5L, owner);
+
+            assertThat(trash.getTrashType()).isNull();
+            assertThat(response.typeCode()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteTrash")
+    class DeleteTrash {
+
+        @Test
+        @DisplayName("본인 쓰레기는 S3 이미지와 DB 레코드를 함께 삭제한다")
+        void 삭제_성공() {
+            Trash trash = trashOf(owner, petType(), null);
+            given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
+
+            trashService.deleteTrash(1L, owner);
+
+            verify(fileStoragePort).deleteFileByUrl("https://storage.test/trash/photo.jpg");
+            verify(trashRepository).delete(trash);
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 쓰레기는 삭제할 수 없다")
+        void 다른_사용자_삭제_불가() {
+            Trash trash = trashOf(owner, petType(), null);
+            given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
+
+            assertThatThrownBy(() -> trashService.deleteTrash(1L, otherUser))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.NOT_EXISTS_TRASH_ITEM));
+            verify(fileStoragePort, never()).deleteFileByUrl(anyString());
+            verify(trashRepository, never()).delete(any(Trash.class));
+        }
+
+        @Test
+        @DisplayName("S3 삭제가 실패하면 S3_DELETE_FAIL 예외가 발생하고 DB 레코드는 유지된다")
+        void S3_삭제_실패() {
+            Trash trash = trashOf(owner, petType(), null);
+            given(trashRepository.findById(1L)).willReturn(Optional.of(trash));
+            willThrow(new RuntimeException("connection refused"))
+                .given(fileStoragePort).deleteFileByUrl(anyString());
+
+            assertThatThrownBy(() -> trashService.deleteTrash(1L, owner))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.S3_DELETE_FAIL));
+            verify(trashRepository, never()).delete(any(Trash.class));
+        }
+    }
+}

--- a/src/test/java/com/trashheroesbe/feature/trash/dto/request/CreateTrashRequestTest.java
+++ b/src/test/java/com/trashheroesbe/feature/trash/dto/request/CreateTrashRequestTest.java
@@ -1,0 +1,72 @@
+package com.trashheroesbe.feature.trash.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+class CreateTrashRequestTest {
+
+    @Test
+    @DisplayName("정상 이미지 파일은 검증을 통과한다")
+    void 정상_이미지() {
+        MockMultipartFile file = new MockMultipartFile(
+            "imageFile", "photo.jpg", "image/jpeg", new byte[]{1, 2, 3});
+
+        assertThatCode(() -> new CreateTrashRequest(file).validate())
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("파일이 null이면 예외가 발생한다")
+    void 파일_없음() {
+        assertThatThrownBy(() -> new CreateTrashRequest(null).validate())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("이미지 파일은 필수");
+    }
+
+    @Test
+    @DisplayName("빈 파일이면 예외가 발생한다")
+    void 빈_파일() {
+        MockMultipartFile file = new MockMultipartFile(
+            "imageFile", "photo.jpg", "image/jpeg", new byte[]{});
+
+        assertThatThrownBy(() -> new CreateTrashRequest(file).validate())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("이미지 파일은 필수");
+    }
+
+    @Test
+    @DisplayName("이미지가 아닌 컨텐츠 타입이면 예외가 발생한다")
+    void 이미지_아님() {
+        MockMultipartFile file = new MockMultipartFile(
+            "imageFile", "doc.pdf", "application/pdf", new byte[]{1, 2, 3});
+
+        assertThatThrownBy(() -> new CreateTrashRequest(file).validate())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("이미지 파일만");
+    }
+
+    @Test
+    @DisplayName("10MB를 초과하는 파일이면 예외가 발생한다")
+    void 크기_초과() {
+        MockMultipartFile file = new MockMultipartFile(
+            "imageFile", "big.jpg", "image/jpeg", new byte[10 * 1024 * 1024 + 1]);
+
+        assertThatThrownBy(() -> new CreateTrashRequest(file).validate())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("10MB");
+    }
+
+    @Test
+    @DisplayName("정확히 10MB인 파일은 검증을 통과한다")
+    void 크기_경계값() {
+        MockMultipartFile file = new MockMultipartFile(
+            "imageFile", "exact.jpg", "image/jpeg", new byte[10 * 1024 * 1024]);
+
+        assertThatCode(() -> new CreateTrashRequest(file).validate())
+            .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/trashheroesbe/feature/trash/dto/request/CreateTrashRequestTest.java
+++ b/src/test/java/com/trashheroesbe/feature/trash/dto/request/CreateTrashRequestTest.java
@@ -12,9 +12,11 @@ class CreateTrashRequestTest {
     @Test
     @DisplayName("정상 이미지 파일은 검증을 통과한다")
     void 정상_이미지() {
+        // given
         MockMultipartFile file = new MockMultipartFile(
             "imageFile", "photo.jpg", "image/jpeg", new byte[]{1, 2, 3});
 
+        // when & then
         assertThatCode(() -> new CreateTrashRequest(file).validate())
             .doesNotThrowAnyException();
     }
@@ -22,6 +24,7 @@ class CreateTrashRequestTest {
     @Test
     @DisplayName("파일이 null이면 예외가 발생한다")
     void 파일_없음() {
+        // when & then
         assertThatThrownBy(() -> new CreateTrashRequest(null).validate())
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("이미지 파일은 필수");
@@ -30,9 +33,11 @@ class CreateTrashRequestTest {
     @Test
     @DisplayName("빈 파일이면 예외가 발생한다")
     void 빈_파일() {
+        // given
         MockMultipartFile file = new MockMultipartFile(
             "imageFile", "photo.jpg", "image/jpeg", new byte[]{});
 
+        // when & then
         assertThatThrownBy(() -> new CreateTrashRequest(file).validate())
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("이미지 파일은 필수");
@@ -41,9 +46,11 @@ class CreateTrashRequestTest {
     @Test
     @DisplayName("이미지가 아닌 컨텐츠 타입이면 예외가 발생한다")
     void 이미지_아님() {
+        // given
         MockMultipartFile file = new MockMultipartFile(
             "imageFile", "doc.pdf", "application/pdf", new byte[]{1, 2, 3});
 
+        // when & then
         assertThatThrownBy(() -> new CreateTrashRequest(file).validate())
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("이미지 파일만");
@@ -52,9 +59,11 @@ class CreateTrashRequestTest {
     @Test
     @DisplayName("10MB를 초과하는 파일이면 예외가 발생한다")
     void 크기_초과() {
+        // given
         MockMultipartFile file = new MockMultipartFile(
             "imageFile", "big.jpg", "image/jpeg", new byte[10 * 1024 * 1024 + 1]);
 
+        // when & then
         assertThatThrownBy(() -> new CreateTrashRequest(file).validate())
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("10MB");
@@ -63,9 +72,11 @@ class CreateTrashRequestTest {
     @Test
     @DisplayName("정확히 10MB인 파일은 검증을 통과한다")
     void 크기_경계값() {
+        // given
         MockMultipartFile file = new MockMultipartFile(
             "imageFile", "exact.jpg", "image/jpeg", new byte[10 * 1024 * 1024]);
 
+        // when & then
         assertThatCode(() -> new CreateTrashRequest(file).validate())
             .doesNotThrowAnyException();
     }

--- a/src/test/java/com/trashheroesbe/fixture/CouponFixture.java
+++ b/src/test/java/com/trashheroesbe/fixture/CouponFixture.java
@@ -1,0 +1,29 @@
+package com.trashheroesbe.fixture;
+
+import com.trashheroesbe.feature.coupon.domain.entity.Coupon;
+import com.trashheroesbe.feature.coupon.domain.type.CouponType;
+import com.trashheroesbe.feature.coupon.domain.type.DiscountType;
+import com.trashheroesbe.feature.partner.domain.entity.Partner;
+
+public class CouponFixture {
+
+    public static Coupon.CouponBuilder builder(Long id, Partner partner) {
+        return Coupon.builder()
+            .id(id)
+            .partner(partner)
+            .title("어스어스 3000원 할인 쿠폰")
+            .content("어스어스에서 3000원 할인받을 수 있는 쿠폰")
+            .type(CouponType.OFFLINE)
+            .pointCost(3000)
+            .discountType(DiscountType.AMOUNT)
+            .discountValue(3000)
+            .totalStock(10)
+            .issuedCount(0)
+            .isActive(true)
+            .version(0L);
+    }
+
+    public static Coupon coupon(Long id, Partner partner) {
+        return builder(id, partner).build();
+    }
+}

--- a/src/test/java/com/trashheroesbe/fixture/PartnerFixture.java
+++ b/src/test/java/com/trashheroesbe/fixture/PartnerFixture.java
@@ -1,0 +1,15 @@
+package com.trashheroesbe.fixture;
+
+import com.trashheroesbe.feature.partner.domain.entity.Partner;
+
+public class PartnerFixture {
+
+    public static Partner partner(Long id) {
+        return Partner.builder()
+            .id(id)
+            .partnerName("어스어스" + id)
+            .email("partner" + id + "@test.com")
+            .password("encoded-password")
+            .build();
+    }
+}

--- a/src/test/java/com/trashheroesbe/fixture/UserFixture.java
+++ b/src/test/java/com/trashheroesbe/fixture/UserFixture.java
@@ -1,0 +1,28 @@
+package com.trashheroesbe.fixture;
+
+import com.trashheroesbe.feature.partner.domain.entity.Partner;
+import com.trashheroesbe.feature.user.domain.entity.User;
+import com.trashheroesbe.feature.user.domain.type.AuthProvider;
+import com.trashheroesbe.feature.user.domain.type.Role;
+
+public class UserFixture {
+
+    public static User user(Long id) {
+        return User.builder()
+            .id(id)
+            .nickname("특공대요원" + id)
+            .provider(AuthProvider.KAKAO)
+            .role(Role.USER)
+            .build();
+    }
+
+    public static User partnerUser(Long id, Partner partner) {
+        return User.builder()
+            .id(id)
+            .nickname(partner.getPartnerName())
+            .provider(AuthProvider.PARTNER)
+            .role(Role.PARTNER)
+            .partner(partner)
+            .build();
+    }
+}

--- a/src/test/java/com/trashheroesbe/global/auth/jwt/service/CookieProviderTest.java
+++ b/src/test/java/com/trashheroesbe/global/auth/jwt/service/CookieProviderTest.java
@@ -1,0 +1,77 @@
+package com.trashheroesbe.global.auth.jwt.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.trashheroesbe.feature.user.domain.entity.User;
+import com.trashheroesbe.feature.user.domain.type.Role;
+import com.trashheroesbe.fixture.UserFixture;
+import com.trashheroesbe.global.auth.jwt.entity.TokenType;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class CookieProviderTest {
+
+    private final CookieProvider cookieProvider = new CookieProvider();
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(cookieProvider, "secureCookie", true);
+    }
+
+    @Test
+    @DisplayName("토큰 쿠키는 HttpOnly·Secure·SameSite=None 속성과 유효 시간을 가진다")
+    void 토큰_쿠키_생성() {
+        // when
+        Cookie cookie = cookieProvider.createTokenCookie(TokenType.ACCESS_TOKEN, "jwt-token");
+
+        // then
+        assertThat(cookie.getName()).isEqualTo("access_token");
+        assertThat(cookie.getValue()).isEqualTo("jwt-token");
+        assertThat(cookie.isHttpOnly()).isTrue();
+        assertThat(cookie.getSecure()).isTrue();
+        assertThat(cookie.getPath()).isEqualTo("/");
+        assertThat(cookie.getAttribute("SameSite")).isEqualTo("None");
+        assertThat(cookie.getMaxAge()).isEqualTo(10_800);
+    }
+
+    @Test
+    @DisplayName("만료 쿠키는 값이 없고 유효 시간이 0이다")
+    void 만료_쿠키_생성() {
+        // when
+        Cookie cookie = cookieProvider.createExpiredCookie(TokenType.ACCESS_TOKEN);
+
+        // then
+        assertThat(cookie.getName()).isEqualTo("access_token");
+        assertThat(cookie.getValue()).isNull();
+        assertThat(cookie.getMaxAge()).isZero();
+    }
+
+    @Test
+    @DisplayName("게스트 사용자는 isMember=false 쿠키를 받는다")
+    void 게스트_회원_여부() {
+        // given
+        User guest = User.builder().id(3L).nickname("게스트").role(Role.GUEST).build();
+
+        // when
+        Cookie cookie = cookieProvider.createRoleCheckCookie(TokenType.ACCESS_TOKEN, guest);
+
+        // then
+        assertThat(cookie.getName()).isEqualTo("isMember");
+        assertThat(cookie.getValue()).isEqualTo("false");
+    }
+
+    @Test
+    @DisplayName("일반 사용자는 isMember=true 쿠키를 받는다")
+    void 일반_회원_여부() {
+        // when
+        Cookie cookie = cookieProvider.createRoleCheckCookie(
+            TokenType.ACCESS_TOKEN, UserFixture.user(1L));
+
+        // then
+        assertThat(cookie.getName()).isEqualTo("isMember");
+        assertThat(cookie.getValue()).isEqualTo("true");
+    }
+}

--- a/src/test/java/com/trashheroesbe/global/qrcode/QrCodeGeneratorTest.java
+++ b/src/test/java/com/trashheroesbe/global/qrcode/QrCodeGeneratorTest.java
@@ -1,0 +1,53 @@
+package com.trashheroesbe.global.qrcode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.zxing.BinaryBitmap;
+import com.google.zxing.MultiFormatReader;
+import com.google.zxing.Result;
+import com.google.zxing.client.j2se.BufferedImageLuminanceSource;
+import com.google.zxing.common.HybridBinarizer;
+import com.trashheroesbe.global.exception.BusinessException;
+import com.trashheroesbe.global.response.type.ErrorCode;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class QrCodeGeneratorTest {
+
+    private final QrCodeGenerator qrCodeGenerator = new QrCodeGenerator();
+
+    @Test
+    @DisplayName("요청 크기의 PNG QR 이미지를 생성하고 내용을 다시 읽을 수 있다")
+    void 생성_라운드트립() throws Exception {
+        // given
+        String content = "https://trash-heroes.store/qr?userCouponId=100&qrToken=token-123";
+
+        // when
+        byte[] png = qrCodeGenerator.generatePngBytes(content, 300);
+
+        // then
+        assertThat(png).isNotEmpty();
+        assertThat(png[0]).isEqualTo((byte) 0x89);
+
+        BufferedImage image = ImageIO.read(new ByteArrayInputStream(png));
+        assertThat(image.getWidth()).isEqualTo(300);
+        assertThat(image.getHeight()).isEqualTo(300);
+
+        Result decoded = new MultiFormatReader().decode(new BinaryBitmap(
+            new HybridBinarizer(new BufferedImageLuminanceSource(image))));
+        assertThat(decoded.getText()).isEqualTo(content);
+    }
+
+    @Test
+    @DisplayName("내용이 비어 있으면 QR_GENERATION_FAIL 예외가 발생한다")
+    void 빈_내용_예외() {
+        // when & then
+        assertThatThrownBy(() -> qrCodeGenerator.generatePngBytes("", 300))
+            .isInstanceOfSatisfying(BusinessException.class, e ->
+                assertThat(e.getErrorCode()).isEqualTo(ErrorCode.QR_GENERATION_FAIL));
+    }
+}

--- a/src/test/java/com/trashheroesbe/global/util/FileUtilsTest.java
+++ b/src/test/java/com/trashheroesbe/global/util/FileUtilsTest.java
@@ -1,0 +1,52 @@
+package com.trashheroesbe.global.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FileUtilsTest {
+
+    private static final String PREFIX = "trash/";
+
+    @Test
+    @DisplayName("prefix + 타임스탬프_UUID8자리 + 확장자 형식의 키를 생성한다")
+    void 키_형식() {
+        String key = FileUtils.generateStoredKey("photo.jpg", PREFIX);
+
+        assertThat(key).matches("trash/\\d{8}_\\d{6}_[0-9a-f]{8}\\.jpg");
+    }
+
+    @Test
+    @DisplayName("원본 파일명의 확장자를 보존한다")
+    void 확장자_보존() {
+        assertThat(FileUtils.generateStoredKey("image.PNG", PREFIX)).endsWith(".PNG");
+        assertThat(FileUtils.generateStoredKey("archive.tar.gz", PREFIX)).endsWith(".gz");
+    }
+
+    @Test
+    @DisplayName("확장자가 없는 파일명은 확장자 없이 키를 생성한다")
+    void 확장자_없음() {
+        String key = FileUtils.generateStoredKey("noextension", PREFIX);
+
+        assertThat(key).matches("trash/\\d{8}_\\d{6}_[0-9a-f]{8}");
+    }
+
+    @Test
+    @DisplayName("점으로 시작하는 파일명은 확장자로 취급하지 않는다")
+    void 숨김_파일() {
+        String key = FileUtils.generateStoredKey(".hidden", PREFIX);
+
+        assertThat(key).doesNotContain(".hidden");
+        assertThat(key).matches("trash/\\d{8}_\\d{6}_[0-9a-f]{8}");
+    }
+
+    @Test
+    @DisplayName("같은 파일명으로 생성해도 매번 다른 키가 나온다")
+    void 키_유일성() {
+        String first = FileUtils.generateStoredKey("photo.jpg", PREFIX);
+        String second = FileUtils.generateStoredKey("photo.jpg", PREFIX);
+
+        assertThat(first).isNotEqualTo(second);
+    }
+}

--- a/src/test/java/com/trashheroesbe/global/util/FileUtilsTest.java
+++ b/src/test/java/com/trashheroesbe/global/util/FileUtilsTest.java
@@ -12,31 +12,45 @@ class FileUtilsTest {
     @Test
     @DisplayName("prefix + 타임스탬프_UUID8자리 + 확장자 형식의 키를 생성한다")
     void 키_형식() {
-        String key = FileUtils.generateStoredKey("photo.jpg", PREFIX);
+        // given
+        String originalFileName = "photo.jpg";
 
+        // when
+        String key = FileUtils.generateStoredKey(originalFileName, PREFIX);
+
+        // then
         assertThat(key).matches("trash/\\d{8}_\\d{6}_[0-9a-f]{8}\\.jpg");
     }
 
     @Test
     @DisplayName("원본 파일명의 확장자를 보존한다")
     void 확장자_보존() {
-        assertThat(FileUtils.generateStoredKey("image.PNG", PREFIX)).endsWith(".PNG");
-        assertThat(FileUtils.generateStoredKey("archive.tar.gz", PREFIX)).endsWith(".gz");
+        // when
+        String upperCaseKey = FileUtils.generateStoredKey("image.PNG", PREFIX);
+        String multiDotKey = FileUtils.generateStoredKey("archive.tar.gz", PREFIX);
+
+        // then
+        assertThat(upperCaseKey).endsWith(".PNG");
+        assertThat(multiDotKey).endsWith(".gz");
     }
 
     @Test
     @DisplayName("확장자가 없는 파일명은 확장자 없이 키를 생성한다")
     void 확장자_없음() {
+        // when
         String key = FileUtils.generateStoredKey("noextension", PREFIX);
 
+        // then
         assertThat(key).matches("trash/\\d{8}_\\d{6}_[0-9a-f]{8}");
     }
 
     @Test
     @DisplayName("점으로 시작하는 파일명은 확장자로 취급하지 않는다")
     void 숨김_파일() {
+        // when
         String key = FileUtils.generateStoredKey(".hidden", PREFIX);
 
+        // then
         assertThat(key).doesNotContain(".hidden");
         assertThat(key).matches("trash/\\d{8}_\\d{6}_[0-9a-f]{8}");
     }
@@ -44,9 +58,14 @@ class FileUtilsTest {
     @Test
     @DisplayName("같은 파일명으로 생성해도 매번 다른 키가 나온다")
     void 키_유일성() {
-        String first = FileUtils.generateStoredKey("photo.jpg", PREFIX);
-        String second = FileUtils.generateStoredKey("photo.jpg", PREFIX);
+        // given
+        String originalFileName = "photo.jpg";
 
+        // when
+        String first = FileUtils.generateStoredKey(originalFileName, PREFIX);
+        String second = FileUtils.generateStoredKey(originalFileName, PREFIX);
+
+        // then
         assertThat(first).isNotEqualTo(second);
     }
 }

--- a/src/test/java/com/trashheroesbe/global/util/UserCouponQrUtilTest.java
+++ b/src/test/java/com/trashheroesbe/global/util/UserCouponQrUtilTest.java
@@ -1,0 +1,25 @@
+package com.trashheroesbe.global.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserCouponQrUtilTest {
+
+    @Test
+    @DisplayName("QR 페이로드는 baseUrl에 userCouponId와 qrToken 쿼리를 붙인다")
+    void 페이로드_형식() {
+        String payload = UserCouponQrUtil.buildPayload(
+            "https://trash-heroes.store/qr", 100L, "token-123");
+
+        assertThat(payload)
+            .isEqualTo("https://trash-heroes.store/qr?userCouponId=100&qrToken=token-123");
+    }
+
+    @Test
+    @DisplayName("QR 저장 키는 user-coupon/{id}/qr.png 형식이다")
+    void 저장_키_형식() {
+        assertThat(UserCouponQrUtil.buildKey(100L)).isEqualTo("user-coupon/100/qr.png");
+    }
+}

--- a/src/test/java/com/trashheroesbe/global/util/UserCouponQrUtilTest.java
+++ b/src/test/java/com/trashheroesbe/global/util/UserCouponQrUtilTest.java
@@ -10,9 +10,13 @@ class UserCouponQrUtilTest {
     @Test
     @DisplayName("QR 페이로드는 baseUrl에 userCouponId와 qrToken 쿼리를 붙인다")
     void 페이로드_형식() {
-        String payload = UserCouponQrUtil.buildPayload(
-            "https://trash-heroes.store/qr", 100L, "token-123");
+        // given
+        String baseUrl = "https://trash-heroes.store/qr";
 
+        // when
+        String payload = UserCouponQrUtil.buildPayload(baseUrl, 100L, "token-123");
+
+        // then
         assertThat(payload)
             .isEqualTo("https://trash-heroes.store/qr?userCouponId=100&qrToken=token-123");
     }
@@ -20,6 +24,10 @@ class UserCouponQrUtilTest {
     @Test
     @DisplayName("QR 저장 키는 user-coupon/{id}/qr.png 형식이다")
     void 저장_키_형식() {
-        assertThat(UserCouponQrUtil.buildKey(100L)).isEqualTo("user-coupon/100/qr.png");
+        // when
+        String key = UserCouponQrUtil.buildKey(100L);
+
+        // then
+        assertThat(key).isEqualTo("user-coupon/100/qr.png");
     }
 }

--- a/src/test/java/com/trashheroesbe/infrastructure/adapter/out/gpt/OpenAIChatAdapterTest.java
+++ b/src/test/java/com/trashheroesbe/infrastructure/adapter/out/gpt/OpenAIChatAdapterTest.java
@@ -1,0 +1,223 @@
+package com.trashheroesbe.infrastructure.adapter.out.gpt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trashheroesbe.feature.trash.domain.type.Type;
+import com.trashheroesbe.feature.trash.infrastructure.TrashItemRepository;
+import com.trashheroesbe.global.exception.BusinessException;
+import com.trashheroesbe.global.response.type.ErrorCode;
+import com.trashheroesbe.infrastructure.adapter.out.gpt.dto.SimilarResult;
+import com.trashheroesbe.infrastructure.port.gpt.ImageAnalysisBundle;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.chat.client.ChatClient;
+
+@ExtendWith(MockitoExtension.class)
+class OpenAIChatAdapterTest {
+
+    @Mock
+    private TrashItemRepository trashItemRepository;
+
+    private ChatClient chatClient;
+    private OpenAIChatAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        chatClient = mock(ChatClient.class, RETURNS_DEEP_STUBS);
+        adapter = new OpenAIChatAdapter(new ObjectMapper(), chatClient, trashItemRepository);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubVisionResponse(String content) {
+        given(chatClient.prompt()
+            .system(anyString())
+            .user(any(Consumer.class))
+            .call()
+            .content())
+            .willReturn(content);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubVisionFailure() {
+        given(chatClient.prompt()
+            .system(anyString())
+            .user(any(Consumer.class))
+            .call()
+            .content())
+            .willThrow(new RuntimeException("OpenAI 호출 실패"));
+    }
+
+    private void stubTextResponse(String content) {
+        given(chatClient.prompt()
+            .user(anyString())
+            .call()
+            .content())
+            .willReturn(content);
+    }
+
+    @Nested
+    @DisplayName("analyzeAll")
+    class AnalyzeAll {
+
+        @Test
+        @DisplayName("코드블록이 섞인 응답에서 JSON만 추출해 타입·품목·부품을 파싱한다")
+        void 응답_파싱() {
+            // given
+            stubVisionResponse("""
+                ```json
+                {"type":"PET","itemName":"PET(투명 페트병)","name":"투명 페트병",
+                 "parts":[{"name":"뚜껑","type":"PLASTIC"},
+                          {"name":"","type":"PLASTIC"},
+                          {"name":"라벨","type":"WRONG_TYPE"}]}
+                ```""");
+
+            // when
+            ImageAnalysisBundle bundle = adapter.analyzeAll(new byte[]{1, 2, 3}, "image/jpeg");
+
+            // then
+            assertThat(bundle.type()).isEqualTo(Type.PET);
+            assertThat(bundle.itemName()).isEqualTo("PET(투명 페트병)");
+            assertThat(bundle.name()).isEqualTo("투명 페트병");
+            assertThat(bundle.parts()).hasSize(1);
+            assertThat(bundle.parts().get(0).name()).isEqualTo("뚜껑");
+            assertThat(bundle.parts().get(0).type()).isEqualTo(Type.PLASTIC);
+        }
+
+        @Test
+        @DisplayName("허용되지 않은 타입 문자열이면 UNKNOWN으로 파싱한다")
+        void 잘못된_타입() {
+            // given
+            stubVisionResponse("{\"type\":\"ALIEN\",\"name\":\"외계 물체\"}");
+
+            // when
+            ImageAnalysisBundle bundle = adapter.analyzeAll(new byte[]{1}, "image/jpeg");
+
+            // then
+            assertThat(bundle.type()).isEqualTo(Type.UNKNOWN);
+            assertThat(bundle.name()).isEqualTo("외계 물체");
+            assertThat(bundle.parts()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("AI 호출이 실패하면 UNKNOWN 번들로 폴백한다")
+        void 호출_실패_폴백() {
+            // given
+            stubVisionFailure();
+
+            // when
+            ImageAnalysisBundle bundle = adapter.analyzeAll(new byte[]{1}, "image/jpeg");
+
+            // then
+            assertThat(bundle.type()).isEqualTo(Type.UNKNOWN);
+            assertThat(bundle.itemName()).isNull();
+            assertThat(bundle.name()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("findSimilarTrashItem")
+    class FindSimilarTrashItem {
+
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {"", "  "})
+        @DisplayName("키워드가 비어 있으면 INVALID_SEARCH_KEYWORD 예외가 발생한다")
+        void 빈_키워드(String invalidKeyword) {
+            // when & then
+            assertThatThrownBy(() ->
+                adapter.findSimilarTrashItem(invalidKeyword, List.of(), List.of()))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_SEARCH_KEYWORD));
+        }
+
+        @Test
+        @DisplayName("품목명이 매칭되면 itemName 결과를 반환한다")
+        void 품목_매칭() {
+            // given
+            stubTextResponse("{\"itemName\":\"어패류 껍데기\"}");
+
+            // when
+            SimilarResult result = adapter.findSimilarTrashItem(
+                "조개껍질", List.of("어패류 껍데기"), List.of(Type.FOOD_WASTE));
+
+            // then
+            assertThat(result.getItemName()).contains("어패류 껍데기");
+            assertThat(result.getType()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("품목이 없고 타입만 매칭되면 type 결과를 반환한다")
+        void 타입_매칭() {
+            // given
+            stubTextResponse("{\"type\":\"STYROFOAM\"}");
+
+            // when
+            SimilarResult result = adapter.findSimilarTrashItem(
+                "스티로폼 박스", List.of(), List.of(Type.STYROFOAM));
+
+            // then
+            assertThat(result.getType()).contains(Type.STYROFOAM);
+            assertThat(result.getItemName()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("NONE 응답이면 빈 결과를 반환한다")
+        void 매칭_없음() {
+            // given
+            stubTextResponse("{\"itemName\":\"NONE\"}");
+
+            // when
+            SimilarResult result = adapter.findSimilarTrashItem(
+                "정체불명", List.of("어패류 껍데기"), List.of(Type.FOOD_WASTE));
+
+            // then
+            assertThat(result.isNone()).isTrue();
+        }
+
+        @Test
+        @DisplayName("AI 호출이 실패하면 ERROR_GPT_CALL 예외가 발생한다")
+        void 호출_실패() {
+            // given
+            given(chatClient.prompt().user(anyString()).call().content())
+                .willThrow(new RuntimeException("OpenAI 호출 실패"));
+
+            // when & then
+            assertThatThrownBy(() ->
+                adapter.findSimilarTrashItem("조개껍질", List.of(), List.of()))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ERROR_GPT_CALL));
+        }
+
+        @Test
+        @DisplayName("현재 동작 문서화: 빈 응답도 EMPTY_GPT_RESPONSE가 아닌 ERROR_GPT_CALL로 감싸진다")
+        void 빈_응답_에러코드() {
+            // parseSimilarItemNameResponse가 던지는 EMPTY_GPT_RESPONSE가
+            // 바깥 try-catch에서 ERROR_GPT_CALL로 재래핑되어 원래 에러 코드가 가려진다.
+            // given
+            stubTextResponse("");
+
+            // when & then
+            assertThatThrownBy(() ->
+                adapter.findSimilarTrashItem("조개껍질", List.of(), List.of()))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ERROR_GPT_CALL));
+        }
+    }
+}

--- a/src/test/java/com/trashheroesbe/infrastructure/adapter/out/gpt/OpenAIChatAdapterTest.java
+++ b/src/test/java/com/trashheroesbe/infrastructure/adapter/out/gpt/OpenAIChatAdapterTest.java
@@ -206,10 +206,8 @@ class OpenAIChatAdapterTest {
         }
 
         @Test
-        @DisplayName("현재 동작 문서화: 빈 응답도 EMPTY_GPT_RESPONSE가 아닌 ERROR_GPT_CALL로 감싸진다")
+        @DisplayName("빈 응답이면 EMPTY_GPT_RESPONSE 예외가 발생한다")
         void 빈_응답_에러코드() {
-            // parseSimilarItemNameResponse가 던지는 EMPTY_GPT_RESPONSE가
-            // 바깥 try-catch에서 ERROR_GPT_CALL로 재래핑되어 원래 에러 코드가 가려진다.
             // given
             stubTextResponse("");
 
@@ -217,7 +215,20 @@ class OpenAIChatAdapterTest {
             assertThatThrownBy(() ->
                 adapter.findSimilarTrashItem("조개껍질", List.of(), List.of()))
                 .isInstanceOfSatisfying(BusinessException.class, e ->
-                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.ERROR_GPT_CALL));
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.EMPTY_GPT_RESPONSE));
+        }
+
+        @Test
+        @DisplayName("JSON으로 파싱할 수 없는 응답이면 FAIL_PARSING_RESPONSE 예외가 발생한다")
+        void 파싱_불가_응답() {
+            // given
+            stubTextResponse("JSON이 아닌 자유 서술 응답");
+
+            // when & then
+            assertThatThrownBy(() ->
+                adapter.findSimilarTrashItem("조개껍질", List.of(), List.of()))
+                .isInstanceOfSatisfying(BusinessException.class, e ->
+                    assertThat(e.getErrorCode()).isEqualTo(ErrorCode.FAIL_PARSING_RESPONSE));
         }
     }
 }

--- a/src/test/java/com/trashheroesbe/infrastructure/adapter/out/s3/S3FileStorageAdapterTest.java
+++ b/src/test/java/com/trashheroesbe/infrastructure/adapter/out/s3/S3FileStorageAdapterTest.java
@@ -109,10 +109,20 @@ class S3FileStorageAdapterTest {
         }
 
         @Test
-        @DisplayName("다른 호스트라도 경로가 버킷으로 시작하면 키를 추출해 삭제한다")
-        void 경로_버킷_삭제() {
+        @DisplayName("경로가 버킷으로 시작해도 허용된 호스트가 아니면 거부한다")
+        void 다른_호스트_거부() {
+            // when & then
+            assertThatThrownBy(() -> adapter.deleteFileByUrl(
+                "https://other-host.test/" + BUCKET + "/trash/photo.jpg"))
+                .isInstanceOf(IllegalArgumentException.class);
+            verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+        }
+
+        @Test
+        @DisplayName("허용된 호스트면 base 경로와 달라도 버킷 경로에서 키를 추출해 삭제한다")
+        void 동일_호스트_경로_삭제() {
             // when
-            adapter.deleteFileByUrl("https://other-host.test/" + BUCKET + "/trash/photo.jpg");
+            adapter.deleteFileByUrl("https://objectstorage.test/" + BUCKET + "/trash/photo.jpg");
 
             // then
             ArgumentCaptor<DeleteObjectRequest> captor =

--- a/src/test/java/com/trashheroesbe/infrastructure/adapter/out/s3/S3FileStorageAdapterTest.java
+++ b/src/test/java/com/trashheroesbe/infrastructure/adapter/out/s3/S3FileStorageAdapterTest.java
@@ -1,0 +1,145 @@
+package com.trashheroesbe.infrastructure.adapter.out.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@ExtendWith(MockitoExtension.class)
+class S3FileStorageAdapterTest {
+
+    private static final String BUCKET = "trash-heroes-bucket";
+    private static final String BASE_URL =
+        "https://objectstorage.test/n/namespace/b/trash-heroes-bucket/o";
+
+    @Mock
+    private S3Client s3Client;
+
+    @InjectMocks
+    private S3FileStorageAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(adapter, "bucketName", BUCKET);
+        ReflectionTestUtils.setField(adapter, "publicBaseUrl", BASE_URL);
+    }
+
+    @Nested
+    @DisplayName("uploadFile")
+    class UploadFile {
+
+        @Test
+        @DisplayName("버킷·키·컨텐츠 타입으로 업로드하고 공개 URL을 반환한다")
+        void 업로드_성공() {
+            // when
+            String url = adapter.uploadFile("trash/photo.jpg", "image/jpeg", new byte[]{1, 2, 3});
+
+            // then
+            ArgumentCaptor<PutObjectRequest> captor =
+                ArgumentCaptor.forClass(PutObjectRequest.class);
+            verify(s3Client).putObject(captor.capture(), any(RequestBody.class));
+            assertThat(captor.getValue().bucket()).isEqualTo(BUCKET);
+            assertThat(captor.getValue().key()).isEqualTo("trash/photo.jpg");
+            assertThat(captor.getValue().contentType()).isEqualTo("image/jpeg");
+            assertThat(url).isEqualTo(BASE_URL + "/trash/photo.jpg");
+        }
+
+        @Test
+        @DisplayName("base URL 끝에 슬래시가 있어도 이중 슬래시 없이 URL을 만든다")
+        void 슬래시_정규화() {
+            // given
+            ReflectionTestUtils.setField(adapter, "publicBaseUrl", BASE_URL + "/");
+
+            // when
+            String url = adapter.uploadFile("trash/photo.jpg", "image/jpeg", new byte[]{1});
+
+            // then
+            assertThat(url).isEqualTo(BASE_URL + "/trash/photo.jpg");
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteFileByUrl")
+    class DeleteFileByUrl {
+
+        @Test
+        @DisplayName("공개 base URL 형식이면 키를 추출해 삭제한다")
+        void 공개_URL_삭제() {
+            // when
+            adapter.deleteFileByUrl(BASE_URL + "/trash/photo.jpg");
+
+            // then
+            ArgumentCaptor<DeleteObjectRequest> captor =
+                ArgumentCaptor.forClass(DeleteObjectRequest.class);
+            verify(s3Client).deleteObject(captor.capture());
+            assertThat(captor.getValue().bucket()).isEqualTo(BUCKET);
+            assertThat(captor.getValue().key()).isEqualTo("trash/photo.jpg");
+        }
+
+        @Test
+        @DisplayName("버킷명/키 형식이면 키를 추출해 삭제한다")
+        void 버킷_프리픽스_삭제() {
+            // when
+            adapter.deleteFileByUrl(BUCKET + "/trash/photo.jpg");
+
+            // then
+            ArgumentCaptor<DeleteObjectRequest> captor =
+                ArgumentCaptor.forClass(DeleteObjectRequest.class);
+            verify(s3Client).deleteObject(captor.capture());
+            assertThat(captor.getValue().key()).isEqualTo("trash/photo.jpg");
+        }
+
+        @Test
+        @DisplayName("다른 호스트라도 경로가 버킷으로 시작하면 키를 추출해 삭제한다")
+        void 경로_버킷_삭제() {
+            // when
+            adapter.deleteFileByUrl("https://other-host.test/" + BUCKET + "/trash/photo.jpg");
+
+            // then
+            ArgumentCaptor<DeleteObjectRequest> captor =
+                ArgumentCaptor.forClass(DeleteObjectRequest.class);
+            verify(s3Client).deleteObject(captor.capture());
+            assertThat(captor.getValue().key()).isEqualTo("trash/photo.jpg");
+        }
+
+        @Test
+        @DisplayName("허용되지 않은 URL이면 예외가 발생하고 삭제 요청을 보내지 않는다")
+        void 허용되지_않은_URL() {
+            // when & then
+            assertThatThrownBy(() ->
+                adapter.deleteFileByUrl("https://evil.test/other-bucket/photo.jpg"))
+                .isInstanceOf(IllegalArgumentException.class);
+            verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @ValueSource(strings = {"", "  "})
+        @DisplayName("URL이 비어 있으면 예외가 발생한다")
+        void 빈_URL(String invalidUrl) {
+            // when & then
+            assertThatThrownBy(() -> adapter.deleteFileByUrl(invalidUrl))
+                .isInstanceOf(IllegalArgumentException.class);
+            verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+        }
+    }
+}


### PR DESCRIPTION
## ✅ 작업 내용
- 테스트 픽스처(User/Partner/Coupon) 구축 및 단위 테스트 93개 추가 (전부 given-when-then 형식)
  - 도메인: Coupon 재고·부분 수정 규칙, UserCoupon 상태 전이·QR 검증
  - 서비스: CouponService 파트너 소유권 검증, CouponStoreService 구매 플로우(재고·포인트·QR), TrashService 생성·조회·품목 변경·삭제
  - 어댑터/인프라: S3FileStorageAdapter 업로드·삭제 URL 검증, OpenAIChatAdapter 응답 파싱, QrCodeGenerator 라운드트립, CookieProvider 속성
- 테스트 작성 과정에서 발견한 버그 3건 수정
  - `useCoupon`이 쿠폰 소속 파트너를 검증하지 않아 다른 파트너의 쿠폰도 사용 처리되던 문제
  - `changeTrashItem`이 리다이렉트 없는 CAUTION 품목 선택 시 쓰레기 타입을 null로 덮던 가드 조건 오류
  - GPT 유사 품목 검색에서 EMPTY_GPT_RESPONSE/FAIL_PARSING_RESPONSE가 ERROR_GPT_CALL로 재래핑되어 원인이 가려지던 문제

## 🤔 고민 했던 부분
- 버그를 발견했을 때 테스트 커밋에서 바로 고치지 않고, 먼저 @Disabled/특성화 테스트로 현재 동작을 문서화한 뒤 별도 fix 커밋에서 수정과 함께 회귀 테스트로 전환했습니다. 테스트가 버그를 찾아낸 과정이 커밋 히스토리에 남도록 하기 위함입니다.
- createTrash의 TransactionTemplate은 PlatformTransactionManager를 목으로 주입하면 콜백이 인라인 실행되는 점을 이용해 트랜잭션 내부 로직까지 단위 테스트로 검증했습니다.
- 자치구(District) 관련 로직은 엔티티에 빌더가 없어 단위 테스트에서 제외하고 통합 테스트 단계로 미뤘습니다.

## 🚨 참고 사항
- 기존 contextLoads 테스트는 로컬 MySQL 없이는 실패해 @Disabled 처리했습니다. Testcontainers 기반 통합 테스트 환경 구성 시 활성화 예정입니다.
- 후속 작업: Testcontainers 통합 테스트, createTrash 병렬 처리 전용 스레드풀 분리

## 🚀 기대 효과
- 리팩토링 시 동작 보존을 검증할 회귀 안전망 확보
- 소유권 검증 누락 등 권한 관련 결함 수정으로 파트너 기능 안정성 향상
- Port(FileStoragePort/ChatAIClientPort) 목 교체 방식의 테스트로 헥사고날 구조의 테스트 용이성 입증

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 다른 파트너의 쿠폰을 사용하려는 접근을 차단했습니다.
  * 쓰레기 항목 전환 시 리다이렉트 정보가 있는 경우에만 재분류하도록 수정했습니다.
  * GPT 처리 중 발생한 의도된 오류가 올바르게 전달됩니다.

* **테스트**
  * 쿠폰, 쓰레기 분류, QR 코드, 파일 저장 등 주요 기능의 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->